### PR TITLE
docs: update installation method to use uv as primary package manager

### DIFF
--- a/agentos/get-started/deploying-first-agent.mdx
+++ b/agentos/get-started/deploying-first-agent.mdx
@@ -22,7 +22,8 @@ You focus on building intelligent agents, AgentOS handles everything else.
 Install the Upsonic Framework to build your agents:
 
 ```bash
-pip install upsonic
+uv pip install upsonic
+# pip install upsonic
 ```
 
 The Upsonic Framework provides the tools to create AI agents with tasks, tools, memory, and more.

--- a/concepts/knowledgebase/loaders/csv.mdx
+++ b/concepts/knowledgebase/loaders/csv.mdx
@@ -14,7 +14,8 @@ CSV loader processes CSV files with options to create documents per row, per chu
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/loaders/docx.mdx
+++ b/concepts/knowledgebase/loaders/docx.mdx
@@ -14,7 +14,8 @@ DOCX loader extracts content from Microsoft Word documents (.docx). Supports ext
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/loaders/html.mdx
+++ b/concepts/knowledgebase/loaders/html.mdx
@@ -14,7 +14,8 @@ HTML loader extracts content from local HTML files and web URLs. Uses BeautifulS
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/loaders/json.mdx
+++ b/concepts/knowledgebase/loaders/json.mdx
@@ -14,7 +14,8 @@ JSON loader processes JSON and JSONL files with support for single or multi-docu
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/loaders/markdown.mdx
+++ b/concepts/knowledgebase/loaders/markdown.mdx
@@ -14,7 +14,8 @@ Markdown loader processes Markdown files with support for YAML front matter pars
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/loaders/pdfplumber.mdx
+++ b/concepts/knowledgebase/loaders/pdfplumber.mdx
@@ -14,7 +14,8 @@ PdfPlumber loader excels at extracting structured content from PDFs, especially 
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 For OCR functionality:

--- a/concepts/knowledgebase/loaders/pymupdf.mdx
+++ b/concepts/knowledgebase/loaders/pymupdf.mdx
@@ -14,7 +14,8 @@ PyMuPDF loader provides high-performance PDF processing with advanced features l
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 For OCR functionality:

--- a/concepts/knowledgebase/loaders/pypdf.mdx
+++ b/concepts/knowledgebase/loaders/pypdf.mdx
@@ -14,7 +14,8 @@ PyPDF loader extracts text from PDF documents using the `pypdf` library. It supp
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 For OCR functionality:

--- a/concepts/knowledgebase/loaders/text.mdx
+++ b/concepts/knowledgebase/loaders/text.mdx
@@ -14,7 +14,8 @@ Text loader processes various text-based files (.txt, .rst, .log, code files, et
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/loaders/xml.mdx
+++ b/concepts/knowledgebase/loaders/xml.mdx
@@ -14,7 +14,8 @@ XML loader processes XML files using XPath expressions to split documents and ex
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/loaders/yml.mdx
+++ b/concepts/knowledgebase/loaders/yml.mdx
@@ -14,7 +14,8 @@ YAML loader processes YAML files using jq-style queries to split documents and e
 ## Dependencies
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/putting-files.mdx
+++ b/concepts/knowledgebase/putting-files.mdx
@@ -10,7 +10,8 @@ KnowledgeBase accepts multiple types of sources: individual files, directories, 
 ## Dependencies
 
 ```bash
-pip install "upsonic[rag]"
+uv pip install "upsonic[rag]"
+# pip install "upsonic[rag]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/storage-providers/chroma.mdx
+++ b/concepts/knowledgebase/storage-providers/chroma.mdx
@@ -13,7 +13,8 @@ ChromaDB is an open-source vector database designed for embedding search and sim
 ## Dependencies
 
 ```bash
-pip install "upsonic[rag]"
+uv pip install "upsonic[rag]"
+# pip install "upsonic[rag]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/storage-providers/faiss.mdx
+++ b/concepts/knowledgebase/storage-providers/faiss.mdx
@@ -13,7 +13,8 @@ FAISS (Facebook AI Similarity Search) is a library for efficient similarity sear
 ## Dependencies
 
 ```bash
-pip install "upsonic[rag]"
+uv pip install "upsonic[rag]"
+# pip install "upsonic[rag]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/storage-providers/milvus.mdx
+++ b/concepts/knowledgebase/storage-providers/milvus.mdx
@@ -13,7 +13,8 @@ Milvus is an open-source vector database built for scalable similarity search an
 ## Dependencies
 
 ```bash
-pip install "upsonic[rag]"
+uv pip install "upsonic[rag]"
+# pip install "upsonic[rag]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/storage-providers/pgvector.mdx
+++ b/concepts/knowledgebase/storage-providers/pgvector.mdx
@@ -13,7 +13,8 @@ PGVector is a PostgreSQL extension that enables vector similarity search. It sup
 ## Dependencies
 
 ```bash
-pip install "upsonic[rag]"
+uv pip install "upsonic[rag]"
+# pip install "upsonic[rag]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/storage-providers/pinecone.mdx
+++ b/concepts/knowledgebase/storage-providers/pinecone.mdx
@@ -13,7 +13,8 @@ Pinecone is a managed vector database service designed for production-scale simi
 ## Dependencies
 
 ```bash
-pip install "upsonic[rag]"
+uv pip install "upsonic[rag]"
+# pip install "upsonic[rag]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/storage-providers/qdrant.mdx
+++ b/concepts/knowledgebase/storage-providers/qdrant.mdx
@@ -13,7 +13,8 @@ Qdrant is a vector similarity search engine and database. It supports embedded, 
 ## Dependencies
 
 ```bash
-pip install "upsonic[rag]"
+uv pip install "upsonic[rag]"
+# pip install "upsonic[rag]"
 ```
 
 ## Examples

--- a/concepts/knowledgebase/storage-providers/weaviate.mdx
+++ b/concepts/knowledgebase/storage-providers/weaviate.mdx
@@ -13,7 +13,8 @@ Weaviate is an open-source vector database with a GraphQL API. It supports embed
 ## Dependencies
 
 ```bash
-pip install "upsonic[rag]"
+uv pip install "upsonic[rag]"
+# pip install "upsonic[rag]"
 ```
 
 ## Examples

--- a/concepts/stategraph/quickstart.mdx
+++ b/concepts/stategraph/quickstart.mdx
@@ -8,7 +8,8 @@ description: "Build your first StateGraph in 5 minutes"
 StateGraph is included in Upsonic. Make sure you have it installed:
 
 ```bash
-pip install upsonic
+uv pip install upsonic
+# pip install upsonic
 ```
 
 ## Your First Graph

--- a/get-started/installation.mdx
+++ b/get-started/installation.mdx
@@ -14,7 +14,8 @@ Upsonic requires Python 3.10 or higher. Follow the steps below to install the fr
 Install the core Upsonic framework to start building AI agents:
 
 ```bash
-pip install upsonic
+uv pip install upsonic
+# pip install upsonic
 ```
 
 This installs the main framework with all essential features including agents, tasks, teams, memory, tools, and LLM integrations.
@@ -50,7 +51,8 @@ Depending on your use case, you may need additional packages:
 Install RAG dependencies for vector databases and knowledge base operations:
 
 ```bash
-pip install "upsonic[rag]"
+uv pip install "upsonic[rag]"
+# pip install "upsonic[rag]"
 ```
 
 Use this when you need to build RAG pipelines with vector databases like Qdrant, ChromaDB, Pinecone, Weaviate, or FAISS.
@@ -60,7 +62,8 @@ Use this when you need to build RAG pipelines with vector databases like Qdrant,
 Install storage backends for memory and state persistence:
 
 ```bash
-pip install "upsonic[storage]"
+uv pip install "upsonic[storage]"
+# pip install "upsonic[storage]"
 ```
 
 Use this when you need databases like PostgreSQL, MongoDB, Redis, or SQLite for memory management.
@@ -70,7 +73,8 @@ Use this when you need databases like PostgreSQL, MongoDB, Redis, or SQLite for 
 Install additional LLM provider integrations:
 
 ```bash
-pip install "upsonic[models]"
+uv pip install "upsonic[models]"
+# pip install "upsonic[models]"
 ```
 
 Use this when you need providers like Anthropic, Google Gemini, Cohere, Groq, Mistral, or Azure OpenAI.
@@ -80,7 +84,8 @@ Use this when you need providers like Anthropic, Google Gemini, Cohere, Groq, Mi
 Install embedding model providers:
 
 ```bash
-pip install "upsonic[embeddings]"
+uv pip install "upsonic[embeddings]"
+# pip install "upsonic[embeddings]"
 ```
 
 Use this when you need embedding models from OpenAI, Anthropic, Google, Azure, HuggingFace, or local FastEmbed.
@@ -90,7 +95,8 @@ Use this when you need embedding models from OpenAI, Anthropic, Google, Azure, H
 Install loaders to work with various file formats in your knowledge base:
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 Use this when you need to process PDF, DOCX, CSV, Markdown, YAML, HTML, or other document formats.
@@ -100,7 +106,8 @@ Use this when you need to process PDF, DOCX, CSV, Markdown, YAML, HTML, or other
 Install pre-built tools for web search and data retrieval:
 
 ```bash
-pip install "upsonic[tools]"
+uv pip install "upsonic[tools]"
+# pip install "upsonic[tools]"
 ```
 
 Use this when you need tools like DuckDuckGo search, Tavily, Yahoo Finance, or web scraping capabilities.
@@ -110,7 +117,8 @@ Use this when you need tools like DuckDuckGo search, Tavily, Yahoo Finance, or w
 Install OCR capabilities to extract text from images and scanned documents:
 
 ```bash
-pip install "upsonic[ocr]"
+uv pip install "upsonic[ocr]"
+# pip install "upsonic[ocr]"
 ```
 
 Use this when you need OCR providers like EasyOCR, PaddleOCR, Tesseract, or RapidOCR.
@@ -120,7 +128,8 @@ Use this when you need OCR providers like EasyOCR, PaddleOCR, Tesseract, or Rapi
 Install web server dependencies for deploying agents as APIs:
 
 ```bash
-pip install "upsonic[web]"
+uv pip install "upsonic[web]"
+# pip install "upsonic[web]"
 ```
 
 Use this when you need to deploy agents with FastAPI/Uvicorn or use Celery for background tasks.

--- a/get-started/introduction.mdx
+++ b/get-started/introduction.mdx
@@ -13,7 +13,8 @@ You can use the Upsonic Framework to build safety-first AI Agents or teams with 
 You are able to create complex and basic agents in one unified system. Our development process is based on what our community wants. Currently we are doubling down on Safety Engine and OCR capabilities.
 
 ```shellscript
-pip install upsonic
+uv pip install upsonic
+# pip install upsonic
 ```
 
 Put your API keys into your .env file

--- a/get-started/quickstart.mdx
+++ b/get-started/quickstart.mdx
@@ -16,7 +16,8 @@ Your first agent with a simple and powerful AI Agent Development framework.
 Let's create your first agent with Upsonic by creating an Agent, Task, and Tool.
 
 ```bash
-pip install upsonic
+uv pip install upsonic
+# pip install upsonic
 ```
 
 ```python stock_analysis.py
@@ -68,7 +69,8 @@ Learn Details
 Add a knowledge base to provide context and information to your agent.
 
 ```bash
-pip install "upsonic[loaders]"
+uv pip install "upsonic[loaders]"
+# pip install "upsonic[loaders]"
 ```
 
 ```python with_knowledge.py


### PR DESCRIPTION
Improved Installation Documentation: Updated all documentation to use uv as the primary package manager (uv pip install upsonic) with pip kept as a commented alternative, modernizing installation instructions across 24 documentation files including quickstart guides, knowledge base loaders, and vector database providers for better developer experience and alignment with modern Python package management best practices.

Full Changelog address: https://github.com/Upsonic/Docs/compare/master...Upsonic:Docs:docs/update-to-uv-installation

Pull Requests:
* PR name: [made-by Irem Oztimur](https://github.com/IremOztimur) in [#88](https://github.com/Upsonic/Docs/pull/88)