### PR TITLE
fix: add missing quotes around bracket extras in uv pip install command

### DIFF
--- a/concepts/interfaces/Gmail.mdx
+++ b/concepts/interfaces/Gmail.mdx
@@ -11,7 +11,7 @@ Use the Gmail interface to serve Agents via Gmail. It mounts API routes on a Fas
 Install the Gmail interface dependencies:
 
 ```bash
-uv pip install upsonic[gmail-interface]
+uv pip install "upsonic[gmail-interface]"
 ```
 
 ## Setup

--- a/concepts/interfaces/Slack.mdx
+++ b/concepts/interfaces/Slack.mdx
@@ -11,7 +11,7 @@ Use the Slack interface to serve Agents via Slack. It mounts webhook routes on a
 Install the Slack interface dependencies:
 
 ```bash
-uv pip install upsonic[slack-interface]
+uv pip install "upsonic[slack-interface]"
 ```
 
 ## Setup

--- a/concepts/ocr/overview.mdx
+++ b/concepts/ocr/overview.mdx
@@ -22,7 +22,7 @@ The OCR class serves as a high-level orchestrator that:
   **OCR Installation**
 
   ```bash
-  uv pip install upsonic[ocr]
+  uv pip install "upsonic[ocr]"
   ```
 
   This installs Upsonic with OCR dependencies including EasyOCR, RapidOCR, Tesseract, PaddleOCR, and image processing libraries. You'll have access to all OCR providers through a unified interface without needing to configure each one separately.


### PR DESCRIPTION
Adds missing quotes around bracket extras to prevent shell parsing issues.