### PR TITLE
doc: restructure tools, knowledgebase and memory navigation

### DIFF
--- a/concepts/memory/storage-options/async-mem0-storage.mdx
+++ b/concepts/memory/storage-options/async-mem0-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AsyncMem0Storage"
+sidebarTitle: "Mem0 (Async)"
 description: "Async Mem0 Platform and Open Source integration"
 ---
 

--- a/concepts/memory/storage-options/async-mongo-storage.mdx
+++ b/concepts/memory/storage-options/async-mongo-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AsyncMongoStorage"
+sidebarTitle: "MongoDB (Async)"
 description: "Async MongoDB storage for document-based scalable systems"
 ---
 

--- a/concepts/memory/storage-options/async-postgres-storage.mdx
+++ b/concepts/memory/storage-options/async-postgres-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AsyncPostgresStorage"
+sidebarTitle: "PostgreSQL (Async)"
 description: "Async PostgreSQL storage for production systems"
 ---
 

--- a/concepts/memory/storage-options/async-sqlite-storage.mdx
+++ b/concepts/memory/storage-options/async-sqlite-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AsyncSqliteStorage"
+sidebarTitle: "SQLite (Async)"
 description: "Async SQLite database storage for local development"
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -186,6 +186,7 @@
                                     {
                                         "group": "Usage",
                                         "pages": [
+                                            "concepts/tools/tool-locations",
                                             {
                                                 "group": "Custom Tool Creation",
                                                 "pages": [
@@ -220,12 +221,17 @@
                                                             "concepts/tools/custom-tools/tool-configurations/strict",
                                                             "concepts/tools/custom-tools/tool-configurations/docstring-format"
                                                         ]
-                                                    },
-                                                    "concepts/tools/custom-tools/advanced/combining-multiple-tools"
+                                                    }
                                                 ]
-                                            },
+                                            }
+                                        ],
+                                        "collapsed": false
+                                    },
+                                    {
+                                        "group": "Integrations",
+                                        "pages": [
                                             {
-                                                "group": "MCP Tool",
+                                                "group": "MCP Tools",
                                                 "pages": [
                                                     "concepts/tools/mcp-tools/overview",
                                                     "concepts/tools/mcp-tools/mcp-handler",
@@ -248,7 +254,7 @@
                                                 ]
                                             },
                                             {
-                                                "group": "Ready to Use Tools",
+                                                "group": "Ready-to-Use Tools",
                                                 "pages": [
                                                     "concepts/tools/ready-to-use-tools/yfinance-tools",
                                                     "concepts/tools/ready-to-use-tools/duckduckgo",
@@ -272,14 +278,14 @@
                                                         ]
                                                     }
                                                 ]
-                                            },
-                                            "concepts/tools/custom-tools/advanced/agent-as-tool",
-                                            "concepts/tools/tool-locations"
+                                            }
                                         ]
                                     },
                                     {
                                         "group": "Advanced",
                                         "pages": [
+                                            "concepts/tools/custom-tools/advanced/combining-multiple-tools",
+                                            "concepts/tools/custom-tools/advanced/agent-as-tool",
                                             "concepts/tools/advanced/adding-tools",
                                             "concepts/tools/advanced/removing-tools"
                                         ]
@@ -313,7 +319,7 @@
                                         "collapsed": false
                                     },
                                     {
-                                        "group": "Advanced",
+                                        "group": "Integrations",
                                         "pages": [
                                             "concepts/memory/storage-options/async-sqlite-storage",
                                             "concepts/memory/storage-options/async-postgres-storage",
@@ -340,44 +346,69 @@
                                         "collapsed": false
                                     },
                                     {
+                                        "group": "Integrations",
+                                        "pages": [
+                                            {
+                                                "group": "Embedding Providers",
+                                                "pages": [
+                                                    "concepts/knowledgebase/embedding-providers/openai",
+                                                    "concepts/knowledgebase/embedding-providers/azure",
+                                                    "concepts/knowledgebase/embedding-providers/google",
+                                                    "concepts/knowledgebase/embedding-providers/bedrock",
+                                                    "concepts/knowledgebase/embedding-providers/huggingface",
+                                                    "concepts/knowledgebase/embedding-providers/fastembed",
+                                                    "concepts/knowledgebase/embedding-providers/ollama"
+                                                ]
+                                            },
+                                            {
+                                                "group": "Document Loaders",
+                                                "pages": [
+                                                    "concepts/knowledgebase/loaders/pdfplumber",
+                                                    "concepts/knowledgebase/loaders/pymupdf",
+                                                    "concepts/knowledgebase/loaders/pypdf",
+                                                    "concepts/knowledgebase/loaders/docx",
+                                                    "concepts/knowledgebase/loaders/docling",
+                                                    "concepts/knowledgebase/loaders/csv",
+                                                    "concepts/knowledgebase/loaders/json",
+                                                    "concepts/knowledgebase/loaders/markdown",
+                                                    "concepts/knowledgebase/loaders/html",
+                                                    "concepts/knowledgebase/loaders/xml",
+                                                    "concepts/knowledgebase/loaders/yml",
+                                                    "concepts/knowledgebase/loaders/text"
+                                                ]
+                                            },
+                                            {
+                                                "group": "Text Splitters",
+                                                "pages": [
+                                                    "concepts/knowledgebase/splitters/recursive",
+                                                    "concepts/knowledgebase/splitters/semantic",
+                                                    "concepts/knowledgebase/splitters/agentic",
+                                                    "concepts/knowledgebase/splitters/character",
+                                                    "concepts/knowledgebase/splitters/markdown",
+                                                    "concepts/knowledgebase/splitters/html",
+                                                    "concepts/knowledgebase/splitters/json",
+                                                    "concepts/knowledgebase/splitters/python"
+                                                ]
+                                            },
+                                            {
+                                                "group": "Vector Stores",
+                                                "pages": [
+                                                    "concepts/knowledgebase/storage-providers/pgvector",
+                                                    "concepts/knowledgebase/storage-providers/chroma",
+                                                    "concepts/knowledgebase/storage-providers/qdrant",
+                                                    "concepts/knowledgebase/storage-providers/pinecone",
+                                                    "concepts/knowledgebase/storage-providers/milvus",
+                                                    "concepts/knowledgebase/storage-providers/faiss",
+                                                    "concepts/knowledgebase/storage-providers/weaviate",
+                                                    "concepts/knowledgebase/storage-providers/supermemory"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
                                         "group": "Advanced",
                                         "pages": [
-                                            "concepts/knowledgebase/advanced",
-                                            "concepts/knowledgebase/embedding-providers/azure",
-                                            "concepts/knowledgebase/embedding-providers/bedrock",
-                                            "concepts/knowledgebase/embedding-providers/fastembed",
-                                            "concepts/knowledgebase/embedding-providers/google",
-                                            "concepts/knowledgebase/embedding-providers/huggingface",
-                                            "concepts/knowledgebase/embedding-providers/ollama",
-                                            "concepts/knowledgebase/embedding-providers/openai",
-                                            "concepts/knowledgebase/loaders/csv",
-                                            "concepts/knowledgebase/loaders/docling",
-                                            "concepts/knowledgebase/loaders/docx",
-                                            "concepts/knowledgebase/loaders/html",
-                                            "concepts/knowledgebase/loaders/json",
-                                            "concepts/knowledgebase/loaders/markdown",
-                                            "concepts/knowledgebase/loaders/pdfplumber",
-                                            "concepts/knowledgebase/loaders/pymupdf",
-                                            "concepts/knowledgebase/loaders/pypdf",
-                                            "concepts/knowledgebase/loaders/text",
-                                            "concepts/knowledgebase/loaders/xml",
-                                            "concepts/knowledgebase/loaders/yml",
-                                            "concepts/knowledgebase/splitters/agentic",
-                                            "concepts/knowledgebase/splitters/character",
-                                            "concepts/knowledgebase/splitters/html",
-                                            "concepts/knowledgebase/splitters/json",
-                                            "concepts/knowledgebase/splitters/markdown",
-                                            "concepts/knowledgebase/splitters/python",
-                                            "concepts/knowledgebase/splitters/recursive",
-                                            "concepts/knowledgebase/splitters/semantic",
-                                            "concepts/knowledgebase/storage-providers/chroma",
-                                            "concepts/knowledgebase/storage-providers/faiss",
-                                            "concepts/knowledgebase/storage-providers/milvus",
-                                            "concepts/knowledgebase/storage-providers/pgvector",
-                                            "concepts/knowledgebase/storage-providers/pinecone",
-                                            "concepts/knowledgebase/storage-providers/qdrant",
-                                            "concepts/knowledgebase/storage-providers/supermemory",
-                                            "concepts/knowledgebase/storage-providers/weaviate"
+                                            "concepts/knowledgebase/advanced"
                                         ]
                                     }
                                 ]


### PR DESCRIPTION
Reorganizes sidebar navigation to surface integrations clearly across three sections.

- Tools: add Integrations group (MCP Tools, Ready-to-Use Tools, Model Provider Tools); restore Usage for Custom ToolCreation; move advanced patterns to Advanced
- Knowledge Base: replace flat 30-item Advanced group with semantic Integrations subgroups (Embedding Providers, Document Loaders, Text Splitters, Vector Stores)
- Memory: rename Advanced to Integrations; fix async storage sidebar titles to show integration name first (SQLite, PostgreSQL, MongoDB, Mem0