### PR TITLE
doc: add community page with Discord invite and contribution guide

### DIFF
--- a/community.mdx
+++ b/community.mdx
@@ -1,13 +1,13 @@
 ---
 title: Community
-description: Join the Upsonic community — contribute, share ideas, and build together
+description: Join the Upsonic community, contribute, share ideas, and build together
 ---
 
-# Welcome to the Upsonic Community 👋
+# Welcome to the Upsonic Community 💚
 
 Upsonic is built by developers, for developers. Whether you're already using Upsonic in production or just getting started, **we'd love to have you involved**.
 
-<Card title="Join us on Discord" icon="discord" href="https://discord.gg/xvSe83KhXY" horizontal>
+<Card title="Join us on Discord" icon="discord" href="https://discord.gg/7648R8JahY" horizontal>
   Ask questions, share what you're building, and get help from the team and community.
 </Card>
 
@@ -15,7 +15,7 @@ Upsonic is built by developers, for developers. Whether you're already using Ups
 
 ## Contributing
 
-Upsonic is open source under the MIT License and we welcome contributions of all kinds — code, ideas, bug reports, and documentation improvements.
+Upsonic is open source under the MIT License and we welcome contributions of all kinds: code, ideas, bug reports, and documentation improvements.
 
 <Note>
   You don't need to be an expert to contribute. If you've used Upsonic and found something that could be better, that's a great starting point.
@@ -46,14 +46,14 @@ We're actively building and improving these core areas. If any of them excite yo
     - Steps to reproduce it
     - Your environment (Python version, OS, Upsonic version)
 
-    That's it — short and specific is perfect.
+    That's it. Short and specific is perfect.
   </Accordion>
 
   <Accordion title="Suggest a feature or improvement" icon="lightbulb">
     Have an idea that would make Upsonic better? We want to hear it.
 
     - Open a [GitHub issue](https://github.com/Upsonic/Upsonic/issues) with the **feature request** label
-    - Or share it in our [Discord](https://discord.gg/xvSe83KhXY) — sometimes a quick conversation is the best way to start
+    - Or share it in our [Discord](https://discord.gg/7648R8JahY). Sometimes a quick conversation is the best way to start
   </Accordion>
 
   <Accordion title="Submit a pull request" icon="code-pull-request">
@@ -63,12 +63,10 @@ We're actively building and improving these core areas. If any of them excite yo
     2. Create a branch for your change
     3. Make your changes and add tests where applicable
     4. Open a pull request with a clear description of what you did and why
-
-    If you're unsure where to start, look for issues labeled **good first issue** on [GitHub](https://github.com/Upsonic/Upsonic/labels/good%20first%20issue).
   </Accordion>
 
   <Accordion title="Improve the documentation" icon="book">
-    Clear docs help everyone. If you spot a typo, a missing example, or something that could be explained better — feel free to open a PR.
+    Clear docs help everyone. If you spot a typo, a missing example, or something that could be explained better, feel free to open a PR.
   </Accordion>
 </AccordionGroup>
 
@@ -77,7 +75,7 @@ We're actively building and improving these core areas. If any of them excite yo
 ## Get in Touch
 
 <CardGroup cols={2}>
-  <Card title="Discord" icon="discord" href="https://discord.gg/xvSe83KhXY">
+  <Card title="Discord" icon="discord" href="https://discord.gg/7648R8JahY">
     Chat with the community and the Upsonic team in real time.
   </Card>
   <Card title="GitHub Issues" icon="github" href="https://github.com/Upsonic/Upsonic/issues">
@@ -94,5 +92,5 @@ We're actively building and improving these core areas. If any of them excite yo
 ---
 
 <Info>
-  Upsonic is MIT licensed. Every contribution — big or small — makes a difference. Thank you for being part of this. 💚
+  Upsonic is MIT licensed. Every contribution, big or small, makes a difference. Thank you for being part of this. 💚
 </Info>

--- a/community.mdx
+++ b/community.mdx
@@ -1,0 +1,98 @@
+---
+title: Community
+description: Join the Upsonic community — contribute, share ideas, and build together
+---
+
+# Welcome to the Upsonic Community 👋
+
+Upsonic is built by developers, for developers. Whether you're already using Upsonic in production or just getting started, **we'd love to have you involved**.
+
+<Card title="Join us on Discord" icon="discord" href="https://discord.gg/xvSe83KhXY" horizontal>
+  Ask questions, share what you're building, and get help from the team and community.
+</Card>
+
+---
+
+## Contributing
+
+Upsonic is open source under the MIT License and we welcome contributions of all kinds — code, ideas, bug reports, and documentation improvements.
+
+<Note>
+  You don't need to be an expert to contribute. If you've used Upsonic and found something that could be better, that's a great starting point.
+</Note>
+
+### Areas We're Focused On
+
+We're actively building and improving these core areas. If any of them excite you, we'd love your help:
+
+<CardGroup cols={3}>
+  <Card title="Autonomous Agent" icon="robot">
+    Workspace sandboxing, filesystem and shell tools, and multi-step task execution. Ideas for new capabilities or improvements to existing ones are welcome.
+  </Card>
+  <Card title="Safety Engine" icon="shield-check">
+    Policy-based content filtering for PII, compliance, and content moderation. New policy ideas, edge case fixes, and performance improvements are all valuable.
+  </Card>
+  <Card title="OCR" icon="scanner-image">
+    Multi-engine OCR pipeline with PDF and image support. Engine integrations, accuracy improvements, and preprocessing enhancements are great ways to contribute.
+  </Card>
+</CardGroup>
+
+### Ways to Contribute
+
+<AccordionGroup>
+  <Accordion title="Report a bug" icon="bug">
+    Found something broken? Open an issue on [GitHub](https://github.com/Upsonic/Upsonic/issues) with:
+    - A clear description of the problem
+    - Steps to reproduce it
+    - Your environment (Python version, OS, Upsonic version)
+
+    That's it — short and specific is perfect.
+  </Accordion>
+
+  <Accordion title="Suggest a feature or improvement" icon="lightbulb">
+    Have an idea that would make Upsonic better? We want to hear it.
+
+    - Open a [GitHub issue](https://github.com/Upsonic/Upsonic/issues) with the **feature request** label
+    - Or share it in our [Discord](https://discord.gg/xvSe83KhXY) — sometimes a quick conversation is the best way to start
+  </Accordion>
+
+  <Accordion title="Submit a pull request" icon="code-pull-request">
+    Ready to write some code?
+
+    1. Fork the [repository](https://github.com/Upsonic/Upsonic)
+    2. Create a branch for your change
+    3. Make your changes and add tests where applicable
+    4. Open a pull request with a clear description of what you did and why
+
+    If you're unsure where to start, look for issues labeled **good first issue** on [GitHub](https://github.com/Upsonic/Upsonic/labels/good%20first%20issue).
+  </Accordion>
+
+  <Accordion title="Improve the documentation" icon="book">
+    Clear docs help everyone. If you spot a typo, a missing example, or something that could be explained better — feel free to open a PR.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Get in Touch
+
+<CardGroup cols={2}>
+  <Card title="Discord" icon="discord" href="https://discord.gg/xvSe83KhXY">
+    Chat with the community and the Upsonic team in real time.
+  </Card>
+  <Card title="GitHub Issues" icon="github" href="https://github.com/Upsonic/Upsonic/issues">
+    Report bugs, request features, and track progress.
+  </Card>
+  <Card title="X (Twitter)" icon="x-twitter" href="https://x.com/UpsonicAI">
+    Follow us for updates and announcements.
+  </Card>
+  <Card title="LinkedIn" icon="linkedin" href="https://www.linkedin.com/company/getupsonic/">
+    Connect with us professionally.
+  </Card>
+</CardGroup>
+
+---
+
+<Info>
+  Upsonic is MIT licensed. Every contribution — big or small — makes a difference. Thank you for being part of this. 💚
+</Info>

--- a/docs.json
+++ b/docs.json
@@ -1052,7 +1052,7 @@
     },
     "footer": {
         "socials": {
-            "discord": "https://discord.gg/xvSe83KhXY",
+            "discord": "https://discord.gg/7648R8JahY",
             "x": "https://x.com/UpsonicAI",
             "github": "https://github.com/Upsonic",
             "linkedin": "https://www.linkedin.com/company/getupsonic/"

--- a/docs.json
+++ b/docs.json
@@ -1003,6 +1003,17 @@
                 ]
             },
             {
+                "tab": "Community",
+                "groups": [
+                    {
+                        "group": "Community",
+                        "pages": [
+                            "community"
+                        ]
+                    }
+                ]
+            },
+            {
                 "tab": "Changelog",
                 "groups": [
                     {
@@ -1041,6 +1052,7 @@
     },
     "footer": {
         "socials": {
+            "discord": "https://discord.gg/xvSe83KhXY",
             "x": "https://x.com/UpsonicAI",
             "github": "https://github.com/Upsonic",
             "linkedin": "https://www.linkedin.com/company/getupsonic/"

--- a/ready-to-use-snippets/bootstrap.mdx
+++ b/ready-to-use-snippets/bootstrap.mdx
@@ -5,6 +5,19 @@ read_when:
   - Bootstrapping a workspace manually
 ---
 
+The `BOOTSTRAP.md` file is the first-run ritual for new agents. Place it inside your **workspace** directory and when the agent starts for the first time, it will follow the bootstrap instructions to establish its identity, learn about the user, and set up the workspace.
+
+## How It Works
+
+1. Create a file called `BOOTSTRAP.md` in your workspace folder
+2. On first run, the agent reads it and walks through the setup with the user
+3. Once complete, the agent deletes `BOOTSTRAP.md` — it's no longer needed
+
+## Template
+
+Copy and customize this template for your use case:
+
+```markdown
 # BOOTSTRAP.md - Hello, World
 
 _You just woke up. Time to figure out who you are._
@@ -60,3 +73,4 @@ Delete this file. You don't need a bootstrap script anymore — you're you now.
 ---
 
 _Good luck out there. Make it count._
+```


### PR DESCRIPTION
Adds a new Community page to the docs and registers it as a tab in the navigation

- New community.mdx with Discord CTA, contribution areas (Autonomous Agent, Safety Engine, OCR), and ways to contribute
- Community tab added to docs.json navigation
- Discord added to footer socials