### PR TITLE
doc: redesign video walkthroughs section and add hero video

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -947,7 +947,7 @@
                         ]
                     },
                     {
-                        "group": "Video Examples",
+                        "group": "Video Walkthroughs",
                         "pages": [
                             "examples/video-examples/find-agreement-links",
                             "examples/video-examples/find-example-product",

--- a/examples/overview/introduction.mdx
+++ b/examples/overview/introduction.mdx
@@ -10,27 +10,57 @@ Welcome to Upsonic's example gallery! Here you'll discover examples showcasing e
 
 Have an interesting example to share? Please consider [contributing](https://github.com/Upsonic/Upsonic) to our growing collection.
 
+## See It in Action
+
+Watch how Upsonic agents work in real-world scenarios. This DevOps Telegram Bot monitors servers, analyzes logs, and manages backups directly from a chat interface:
+
+<iframe src="https://www.youtube.com/embed/ulUEFIolesQ" title="DevOps Telegram Bot Demo" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+
+<Tip>Many of our examples include step-by-step video walkthroughs. Look for the 🎬 tag below to find them.</Tip>
+
 ## Getting Started
 
 If you're just getting started, follow the [Getting Started](/get-started/quickstart) guide for a step-by-step tutorial. The examples build on each other, introducing new concepts and capabilities progressively.
 
-## Video Examples
+## 🎬 Video Walkthroughs
+
+These examples include step-by-step video explanations to help you follow along visually.
+
+### Autonomous Agents
+
+<CardGroup cols={2}>
+
+  <Card title="🎬 DevOps Telegram Bot" icon="robot" iconType="duotone" href="/examples/autonomous-agents/devops-telegram-bot">
+
+    Server monitoring, log analysis, and backups from Telegram
+
+  </Card>
+
+  <Card title="🎬 Expense Tracker Bot" icon="receipt" iconType="duotone" href="/examples/autonomous-agents/expense-tracker-bot">
+
+    OCR receipt scanning and expense tracking via Telegram
+
+  </Card>
+
+</CardGroup>
+
+### Web Scraping & Data Extraction
 
 <CardGroup cols={3}>
 
-  <Card title="Find Agreement Links" icon="link" iconType="duotone" href="/examples/video-examples/find-agreement-links">
+  <Card title="🎬 Find Agreement Links" icon="link" iconType="duotone" href="/examples/video-examples/find-agreement-links">
 
     Autonomously find and verify policy pages on websites
 
   </Card>
 
-  <Card title="Classify Emails" icon="envelope" iconType="duotone" href="/examples/video-examples/classify-emails">
+  <Card title="🎬 Classify Emails" icon="envelope" iconType="duotone" href="/examples/video-examples/classify-emails">
 
     Automatically categorize fintech operation emails
 
   </Card>
 
-  <Card title="Find Example Product" icon="shopping-cart" iconType="duotone" href="/examples/video-examples/find-example-product">
+  <Card title="🎬 Find Example Product" icon="shopping-cart" iconType="duotone" href="/examples/video-examples/find-example-product">
 
     Explore ecommerce sites and extract product data
 
@@ -98,24 +128,6 @@ If you're just getting started, follow the [Getting Started](/get-started/quicks
 
 </CardGroup>
 
-## Autonomous Agents
-
-<CardGroup cols={2}>
-
-  <Card title="DevOps Telegram Bot" icon="robot" iconType="duotone" href="/examples/autonomous-agents/devops-telegram-bot">
-
-    Server monitoring, log analysis, and backups from Telegram
-
-  </Card>
-
-  <Card title="Expense Tracker Bot" icon="receipt" iconType="duotone" href="/examples/autonomous-agents/expense-tracker-bot">
-
-    OCR receipt scanning and expense tracking via Telegram
-
-  </Card>
-
-</CardGroup>
-
 ## Model Integrations
 
 <CardGroup cols={2}>
@@ -133,4 +145,3 @@ If you're just getting started, follow the [Getting Started](/get-started/quicks
   </Card>
 
 </CardGroup>
-

--- a/get-started/examples.mdx
+++ b/get-started/examples.mdx
@@ -17,13 +17,20 @@ Examples help you:
 
 ## Example Categories
 
-### Video Examples
+### 🎬 Video Walkthroughs
 
-Watch our video tutorials demonstrating complete workflows from start to finish.
+These examples include step-by-step video explanations so you can follow along visually.
 
-- [Find Agreement Links](/examples/video-examples/find-agreement-links) - Autonomously find and verify policy pages on websites
-- [Classify Emails](/examples/video-examples/classify-emails) - Automatically categorize fintech operation emails
-- [Find Example Product](/examples/video-examples/find-example-product) - Explore ecommerce sites and extract product data
+**Autonomous Agents**
+
+- 🎬 [DevOps Telegram Bot](/examples/autonomous-agents/devops-telegram-bot) - Server monitoring, log analysis, and backups from Telegram
+- 🎬 [Expense Tracker Bot](/examples/autonomous-agents/expense-tracker-bot) - OCR receipt scanning and expense tracking via Telegram
+
+**Web Scraping & Data Extraction**
+
+- 🎬 [Find Agreement Links](/examples/video-examples/find-agreement-links) - Autonomously find and verify policy pages on websites
+- 🎬 [Classify Emails](/examples/video-examples/classify-emails) - Automatically categorize fintech operation emails
+- 🎬 [Find Example Product](/examples/video-examples/find-example-product) - Explore ecommerce sites and extract product data
 
 ### Business & Sales
 
@@ -71,4 +78,3 @@ After exploring examples:
 - Modify examples to fit your specific use case
 - Combine concepts from multiple examples to build complex systems
 - Share your own examples with the [Upsonic community](https://github.com/Upsonic/Upsonic)
-


### PR DESCRIPTION
* Add embedded DevOps agent video to examples introduction page
* Reorganize video examples into categorized Video Walkthroughs section
* Update examples overview page with video walkthrough highlights
* Rename sidebar group from Video Examples to Video Walkthroughs