### PR TITLE
doc: reorganize examples navigation and reorder concepts sidebar 

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -209,41 +209,6 @@
                 ]
               },
               {
-                "group": "Tracing",
-                "icon": "chart-line",
-                "pages": [
-                  "concepts/tracing/overview",
-                  {
-                    "group": "Integrations",
-                    "pages": [
-                      {
-                        "group": "Langfuse",
-                        "pages": [
-                          "concepts/tracing/integrations/langfuse/index",
-                          {
-                            "group": "Advanced",
-                            "pages": [
-                              "concepts/tracing/integrations/langfuse/advanced/scores",
-                              "concepts/tracing/integrations/langfuse/advanced/score-configs",
-                              "concepts/tracing/integrations/langfuse/advanced/datasets",
-                              "concepts/tracing/integrations/langfuse/advanced/annotation-queues",
-                              "concepts/tracing/integrations/langfuse/advanced/update-trace"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "PromptLayer",
-                        "pages": [
-                          "concepts/tracing/integrations/promptlayer/index",
-                          "concepts/tracing/integrations/promptlayer/advanced"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
                 "group": "Tools",
                 "icon": "wrench",
                 "pages": [
@@ -370,6 +335,41 @@
                     ]
                   },
                   "concepts/tools/best-practices"
+                ]
+              },
+              {
+                "group": "Tracing",
+                "icon": "chart-line",
+                "pages": [
+                  "concepts/tracing/overview",
+                  {
+                    "group": "Integrations",
+                    "pages": [
+                      {
+                        "group": "Langfuse",
+                        "pages": [
+                          "concepts/tracing/integrations/langfuse/index",
+                          {
+                            "group": "Advanced",
+                            "pages": [
+                              "concepts/tracing/integrations/langfuse/advanced/scores",
+                              "concepts/tracing/integrations/langfuse/advanced/score-configs",
+                              "concepts/tracing/integrations/langfuse/advanced/datasets",
+                              "concepts/tracing/integrations/langfuse/advanced/annotation-queues",
+                              "concepts/tracing/integrations/langfuse/advanced/update-trace"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "PromptLayer",
+                        "pages": [
+                          "concepts/tracing/integrations/promptlayer/index",
+                          "concepts/tracing/integrations/promptlayer/advanced"
+                        ]
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1050,16 +1050,11 @@
             ]
           },
           {
-            "group": "Video Walkthroughs",
-            "pages": [
-              "examples/video-examples/find-agreement-links",
-              "examples/video-examples/find-example-product",
-              "examples/video-examples/classify-emails"
-            ]
-          },
-          {
             "group": "Business & Sales",
             "pages": [
+              "examples/business-sales/find-agreement-links",
+              "examples/business-sales/find-example-product",
+              "examples/business-sales/classify-emails",
               "examples/business-sales/company_research_sales_strategy_agent",
               "examples/business-sales/sales_offer_agent",
               "examples/business-sales/find-sales-categories",

--- a/examples/autonomous-agents/devops-telegram-bot.mdx
+++ b/examples/autonomous-agents/devops-telegram-bot.mdx
@@ -1,5 +1,6 @@
 ---
 title: "DevOps Telegram Bot"
+sidebarTitle: "🎬 DevOps Telegram Bot"
 description: "An AutonomousAgent connected to Telegram that monitors servers, analyzes logs, creates backups, and runs shell commands, all from chat."
 ---
 

--- a/examples/autonomous-agents/expense-tracker-bot.mdx
+++ b/examples/autonomous-agents/expense-tracker-bot.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Expense Tracker Bot"
+sidebarTitle: "🎬 Expense Tracker Bot"
 description: "A Telegram bot that reads receipt photos with OCR and tracks expenses to CSV, powered by AutonomousAgent with workspace-driven behavior."
 ---
 

--- a/examples/autonomous-agents/folder-organizer.mdx
+++ b/examples/autonomous-agents/folder-organizer.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Folder Organizer"
+sidebarTitle: "🎬 Folder Organizer"
 description: "An autonomous agent that semantically reorganizes any messy folder into a clean, navigable structure — using only a one-line task and a skill file."
 ---
 

--- a/examples/autonomous-agents/operations-analyst.mdx
+++ b/examples/autonomous-agents/operations-analyst.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Operations Analyst"
+sidebarTitle: "🎬 Operations Analyst"
 description: "A two-task autonomous pipeline that analyzes shipment data, computes delivery KPIs, and generates matplotlib charts, all from workspace-defined behavior."
 ---
 

--- a/examples/business-sales/classify-emails.mdx
+++ b/examples/business-sales/classify-emails.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Classify Emails"
+sidebarTitle: "🎬 Classify Emails"
 description: "Build a lightweight Upsonic LLM agent that classifies fintech operation emails into specific categories."
 
 ---

--- a/examples/business-sales/find-agreement-links.mdx
+++ b/examples/business-sales/find-agreement-links.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Find Agreement Links"
+sidebarTitle: "🎬 Find Agreement Links"
 description: "Build an Upsonic LLM agent that autonomously finds and verifies agreement or policy pages on company websites."
 ---
 

--- a/examples/business-sales/find-example-product.mdx
+++ b/examples/business-sales/find-example-product.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Find Example Product"
+sidebarTitle: "🎬 Find Example Product"
 description: "Build Upsonic LLM agents that autonomously explore ecommerce websites and extract structured product data."
 
 ---

--- a/examples/integration-examples/apify-restaurant-scout.mdx
+++ b/examples/integration-examples/apify-restaurant-scout.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Apify Restaurant Scout"
+sidebarTitle: "🎬 Apify Restaurant Scout"
 description: "Use Upsonic's Agent with ApifyTools to search Google Maps for restaurants and food spots using natural language queries, then save the results as Markdown."
 tag: "new"
 ---

--- a/examples/overview/introduction.mdx
+++ b/examples/overview/introduction.mdx
@@ -42,27 +42,39 @@ These examples include step-by-step video explanations to help you follow along 
 
   </Card>
 
+  <Card title="🎬 Operations Analyst" icon="chart-line" iconType="duotone" href="/examples/autonomous-agents/operations-analyst">
+
+    Analyze shipment data, compute KPIs, and generate charts autonomously
+
+  </Card>
+
+  <Card title="🎬 Folder Organizer" icon="folder-tree" iconType="duotone" href="/examples/autonomous-agents/folder-organizer">
+
+    Semantically reorganize messy folders into clean structures
+
+  </Card>
+
 </CardGroup>
 
 ### Web Scraping & Data Extraction
 
 <CardGroup cols={3}>
 
-  <Card title="🎬 Find Agreement Links" icon="link" iconType="duotone" href="/examples/video-examples/find-agreement-links">
+  <Card title="🎬 Find Agreement Links" icon="link" iconType="duotone" href="/examples/business-sales/find-agreement-links">
 
     Autonomously find and verify policy pages on websites
 
   </Card>
 
-  <Card title="🎬 Classify Emails" icon="envelope" iconType="duotone" href="/examples/video-examples/classify-emails">
+  <Card title="🎬 Find Example Product" icon="shopping-cart" iconType="duotone" href="/examples/business-sales/find-example-product">
 
-    Automatically categorize fintech operation emails
+    Explore ecommerce sites and extract product data
 
   </Card>
 
-  <Card title="🎬 Find Example Product" icon="shopping-cart" iconType="duotone" href="/examples/video-examples/find-example-product">
+  <Card title="🎬 Apify Restaurant Scout" icon="map-location-dot" iconType="duotone" href="/examples/integration-examples/apify-restaurant-scout">
 
-    Explore ecommerce sites and extract product data
+    Search Google Maps for restaurants using natural language queries
 
   </Card>
 
@@ -70,7 +82,13 @@ These examples include step-by-step video explanations to help you follow along 
 
 ## Business & Sales
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
+
+  <Card title="🎬 Classify Emails" icon="envelope" iconType="duotone" href="/examples/business-sales/classify-emails">
+
+    Automatically categorize fintech operation emails
+
+  </Card>
 
   <Card title="Find Sales Categories" icon="tags" iconType="duotone" href="/examples/business-sales/find-sales-categories">
 


### PR DESCRIPTION
- Move Tracing below Tools in concepts sidebar (importance-based ordering)
- Remove Video Walkthroughs group; move examples into semantic categories (business-sales)
- Add Apify to Web Scraping section in examples overview
- Expand Autonomous Agents overview section with all 4 examples
- Add 🎬 sidebarTitle to all pages with YouTube video embeds