### PR TITLE
doc: add MCP agent examples

### DIFF
--- a/concepts/tools/mcp-tools/examples/github-agent.mdx
+++ b/concepts/tools/mcp-tools/examples/github-agent.mdx
@@ -1,0 +1,148 @@
+---
+title: "GitHub MCP Agent"
+description: "Build an autonomous agent that analyzes GitHub repositories and generates reports using the GitHub MCP server"
+sidebarTitle: "GitHub"
+---
+
+## Overview
+
+Build an autonomous agent that connects to GitHub, analyzes repository data — issues, pull requests, commit activity — and generates structured reports in your workspace.
+
+## Prerequisites
+
+- A [GitHub Personal Access Token](https://github.com/settings/tokens) with appropriate scopes (`repo`, `issues`, `pull_requests`)
+- Node.js installed (for `npx`)
+
+## Environment Variables
+
+```bash
+# .env
+GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+ANTHROPIC_API_KEY=your-anthropic-key-here
+```
+
+## Installation
+
+```bash
+# With uv (recommended)
+uv pip install upsonic python-dotenv
+
+# With pip
+pip install upsonic python-dotenv
+```
+
+## Example: Repository Issue Analysis
+
+The agent fetches open issues from a data science repository, categorizes them by label, and writes a summary report to the workspace.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+github_handler = MCPHandler(
+    command="npx -y @modelcontextprotocol/server-github",
+    env={
+        "GITHUB_PERSONAL_ACCESS_TOKEN": os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
+    },
+    timeout_seconds=60,
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./reports",
+)
+
+task = Task(
+    description="""
+    Fetch the open issues from 'pandas-dev/pandas' repository (per_page=10).
+    Categorize each issue by label (bug, enhancement, etc.) and write
+    a short summary report to 'pandas_issues_report.md'.
+    """,
+    tools=[github_handler],
+)
+
+agent.print_do(task)
+```
+
+**Generated output** in `./reports/pandas_issues_report.md`:
+
+```
+# Pandas Open Issues Report
+
+## Issue Summary
+Total issues analyzed: 10
+
+## By Category
+| Label       | Count |
+|-------------|-------|
+| Bug         | 4     |
+| Enhancement | 3     |
+| Docs        | 2     |
+| Regression  | 1     |
+
+## Issue Details
+| #     | Title                          | Labels      |
+|-------|--------------------------------|-------------|
+| 12345 | DataFrame.merge produces ...   | Bug         |
+| ...   | ...                            | ...         |
+```
+
+## Example: Compare Contributor Activity
+
+The agent fetches recent commits from a repository and summarizes contributor activity.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+github_handler = MCPHandler(
+    command="npx -y @modelcontextprotocol/server-github",
+    env={
+        "GITHUB_PERSONAL_ACCESS_TOKEN": os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
+    },
+    timeout_seconds=60,
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./reports",
+)
+
+task = Task(
+    description="""
+    Fetch the last 30 commits from 'scikit-learn/scikit-learn' and write
+    a contributor activity summary to 'sklearn_contributors.md' with
+    a table of authors ranked by commit count.
+    """,
+    tools=[github_handler],
+)
+
+agent.print_do(task)
+```
+
+## Available Tools
+
+The GitHub MCP server exposes tools including:
+
+| Tool | Description |
+|------|-------------|
+| `list_issues` | List issues in a repository |
+| `create_issue` | Create a new issue |
+| `get_pull_request` | Get PR details and diff |
+| `search_repositories` | Search for repositories |
+| `get_file_contents` | Read file contents from a repo |
+| `list_commits` | List recent commits |
+
+## Security Notes
+
+- Use a fine-grained personal access token with only the permissions your agent needs.
+- Store your token in `.env` — never hardcode it.
+- For production, use GitHub Apps with scoped installation tokens instead of personal access tokens.

--- a/concepts/tools/mcp-tools/examples/google-calendar-agent.mdx
+++ b/concepts/tools/mcp-tools/examples/google-calendar-agent.mdx
@@ -1,0 +1,190 @@
+---
+title: "Google Calendar MCP Agent"
+description: "Build an autonomous agent that analyzes your calendar and generates schedule reports"
+sidebarTitle: "Google Calendar"
+---
+
+## Overview
+
+Build an autonomous agent that connects to Google Calendar, analyzes your schedule, and generates time-use reports — meeting load analysis, free slot summaries, and weekly schedule exports.
+
+<Info>
+This example uses [`@cocal/google-calendar-mcp`](https://www.npmjs.com/package/@cocal/google-calendar-mcp), a community-maintained MCP server — not an official Google product. Review the package source and permissions before granting access to your calendar data.
+</Info>
+
+## Prerequisites
+
+- A Google Cloud project with the [Calendar API enabled](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com)
+- OAuth 2.0 credentials (Desktop app type) downloaded as a JSON file
+- Node.js installed (for `npx`)
+
+## Setup
+
+### 1. Create OAuth Credentials
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com)
+2. Create a new project or select an existing one
+3. Enable the [Google Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com)
+4. Go to **Credentials** → **Create Credentials** → **OAuth client ID**
+5. Select **Desktop app** as the application type
+6. Download the credentials JSON file
+7. Add your email as a test user under the [Audience screen](https://console.cloud.google.com/auth/audience)
+
+### 2. Place the Credentials File
+
+Save the downloaded OAuth credentials JSON file to a known path, for example:
+
+```bash
+mkdir -p ~/.config/google-calendar-mcp
+cp /path/to/downloaded-credentials.json ~/.config/google-calendar-mcp/credentials.json
+```
+
+### 3. Authenticate
+
+Run the authentication flow to generate access tokens:
+
+```bash
+export GOOGLE_OAUTH_CREDENTIALS="$HOME/.config/google-calendar-mcp/credentials.json"
+npx @cocal/google-calendar-mcp auth
+```
+
+This opens a browser window where you log in to Google and grant calendar access. The resulting auth tokens are saved automatically.
+
+<Warning>
+If your Google Cloud app is in **test mode** (the default), OAuth tokens expire after 7 days. You will need to re-run the auth command weekly.
+</Warning>
+
+### 4. Environment Variables
+
+```bash
+# .env
+ANTHROPIC_API_KEY=your-anthropic-key-here
+```
+
+## Installation
+
+```bash
+# With uv (recommended)
+uv pip install upsonic python-dotenv
+
+# With pip
+pip install upsonic python-dotenv
+```
+
+## Example: Weekly Time-Use Report
+
+The agent fetches all events for the current week and generates a time-use breakdown report.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+calendar_handler = MCPHandler(
+    command="npx -y @cocal/google-calendar-mcp",
+    env={
+        "GOOGLE_OAUTH_CREDENTIALS": os.path.expanduser(
+            "~/.config/google-calendar-mcp/credentials.json"
+        )
+    },
+    timeout_seconds=60
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./calendar-reports",
+    tools=[calendar_handler]
+)
+
+task = Task(
+    description="""
+    Analyze my calendar for the current week (Monday to Friday).
+
+    1. Fetch all events for each day
+    2. Categorize each event as: meeting, focus_time, 1on1, external, or other
+    3. Calculate hours spent in each category per day
+
+    Write the following files:
+    - 'weekly_schedule.csv' with columns: date, event_title, start_time,
+      end_time, duration_minutes, category, attendee_count
+    - 'time_use_report.md' with:
+      * Daily breakdown table (hours per category per day)
+      * Total meeting hours vs available focus time
+      * Busiest and lightest days
+      * Back-to-back meeting chains (3+ consecutive meetings)
+      * Recommendations for better time management
+    """
+)
+
+agent.print_do(task)
+```
+
+## Example: Availability Finder
+
+The agent analyzes your calendar and generates a free-slots document you can share with others for scheduling.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+calendar_handler = MCPHandler(
+    command="npx -y @cocal/google-calendar-mcp",
+    env={
+        "GOOGLE_OAUTH_CREDENTIALS": os.path.expanduser(
+            "~/.config/google-calendar-mcp/credentials.json"
+        )
+    },
+    timeout_seconds=60
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./calendar-reports",
+    tools=[calendar_handler]
+)
+
+task = Task(
+    description="""
+    Check my calendar for the next 5 business days and find all available
+    slots for a 45-minute meeting.
+
+    Constraints:
+    - Only between 9:00 AM and 5:00 PM
+    - Exclude 12:00 PM - 1:00 PM (lunch)
+    - Require at least 15 minutes buffer between meetings
+
+    Write 'available_slots.md' with:
+    - A clean, shareable list of available time slots grouped by day
+    - Total number of available slots
+    - A note about the timezone
+    """
+)
+
+agent.print_do(task)
+```
+
+## Available Tools
+
+Google Calendar MCP servers typically expose tools including:
+
+| Tool | Description |
+|------|-------------|
+| `list_events` | List events in a time range |
+| `create_event` | Create a new calendar event |
+| `update_event` | Update an existing event |
+| `delete_event` | Delete an event |
+| `get_freebusy` | Check free/busy status |
+
+## Security Notes
+
+- Use OAuth 2.0 with the minimum required scopes (`calendar.events`, `calendar.readonly`).
+- Never commit your OAuth credentials JSON or token files to version control.
+- Auth tokens grant access to your calendar — treat them like passwords.
+- If your app is in test mode, tokens expire after 7 days. Re-run `npx @cocal/google-calendar-mcp auth` to re-authenticate.

--- a/concepts/tools/mcp-tools/examples/notion-agent.mdx
+++ b/concepts/tools/mcp-tools/examples/notion-agent.mdx
@@ -1,0 +1,142 @@
+---
+title: "Notion MCP Agent"
+description: "Build an autonomous agent that syncs Notion databases into local reports and analysis files"
+sidebarTitle: "Notion"
+---
+
+## Overview
+
+Build an autonomous agent that connects to your Notion workspace, pulls data from databases and pages, and generates local analysis files — CSV exports, summary reports, and dashboards.
+
+## Prerequisites
+
+- A [Notion Integration Token](https://www.notion.so/my-integrations) with access to the pages/databases you want to use
+- Node.js installed (for `npx`)
+
+## Environment Variables
+
+```bash
+# .env
+OPENAPI_MCP_HEADERS='{"Authorization": "Bearer ntn_xxxxxxxxxxxxxxxxxxxx", "Notion-Version": "2022-06-28"}'
+ANTHROPIC_API_KEY=your-anthropic-key-here
+```
+
+## Installation
+
+```bash
+# With uv (recommended)
+uv pip install upsonic python-dotenv
+
+# With pip
+pip install upsonic python-dotenv
+```
+
+## Example: Export Project Tracker to CSV
+
+The agent queries a Notion database, extracts project data, and writes a structured CSV and summary report to the workspace.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+notion_handler = MCPHandler(
+    command="npx -y @notionhq/notion-mcp-server",
+    env={
+        "OPENAPI_MCP_HEADERS": os.getenv("OPENAPI_MCP_HEADERS")
+    },
+    timeout_seconds=60
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./exports",
+    tools=[notion_handler]
+)
+
+task = Task(
+    description="""
+    Search my Notion workspace for a database called "Project Tracker".
+    Query all entries and export the data.
+
+    1. Write a CSV file 'projects.csv' with columns:
+       project_name, status, owner, due_date, priority, completion_pct
+    2. Write a summary report 'project_summary.md' with:
+       - Total projects by status (table)
+       - Overdue projects (list with owner and days overdue)
+       - Completion distribution (how many at 0-25%, 25-50%, etc.)
+       - Top risks and recommendations
+    """
+)
+
+agent.print_do(task)
+```
+
+## Example: Meeting Notes Aggregator
+
+The agent searches for all meeting notes from the past week and creates a consolidated action items report.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+notion_handler = MCPHandler(
+    command="npx -y @notionhq/notion-mcp-server",
+    env={
+        "OPENAPI_MCP_HEADERS": os.getenv("OPENAPI_MCP_HEADERS")
+    },
+    timeout_seconds=60
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./weekly-digest",
+    tools=[notion_handler]
+)
+
+task = Task(
+    description="""
+    Search my Notion workspace for all pages under "Meetings" that were
+    edited in the last 7 days.
+
+    For each meeting page, extract:
+    - Meeting title and date
+    - Attendees
+    - Action items (with assignee and deadline if available)
+
+    Write two files:
+    1. 'weekly_action_items.md' — all action items grouped by assignee,
+       sorted by deadline. Include a count per person.
+    2. 'meeting_log.csv' — one row per meeting with columns:
+       date, title, attendee_count, action_item_count
+    """
+)
+
+agent.print_do(task)
+```
+
+## Available Tools
+
+The Notion MCP server exposes tools including:
+
+| Tool | Description |
+|------|-------------|
+| `notion_search` | Search pages and databases |
+| `notion_query_database` | Query a database with filters and sorts |
+| `notion_create_page` | Create a new page |
+| `notion_update_page` | Update page properties |
+| `notion_get_page` | Retrieve a page and its content |
+| `notion_append_block_children` | Add content blocks to a page |
+
+## Security Notes
+
+- Create a dedicated Notion integration for your agent — don't reuse personal tokens.
+- Only share the specific pages and databases your agent needs access to via the integration settings.
+- Store your integration token in `.env` — never hardcode it.

--- a/concepts/tools/mcp-tools/examples/stripe-agent.mdx
+++ b/concepts/tools/mcp-tools/examples/stripe-agent.mdx
@@ -1,0 +1,153 @@
+---
+title: "Stripe MCP Agent"
+description: "Build an autonomous agent that analyzes Stripe payment data and generates revenue reports"
+sidebarTitle: "Stripe"
+---
+
+## Overview
+
+Build an autonomous agent that connects to Stripe, pulls payment and subscription data, and generates revenue analytics — CSV exports, trend reports, and churn analysis — directly in your workspace.
+
+## Prerequisites
+
+- A [Stripe API Key](https://dashboard.stripe.com/apikeys) (use a **test mode** key for development)
+- Node.js installed (for `npx`)
+
+## Environment Variables
+
+```bash
+# .env
+STRIPE_SECRET_KEY=sk_test_xxxxxxxxxxxxxxxxxxxx
+ANTHROPIC_API_KEY=your-anthropic-key-here
+```
+
+## Installation
+
+```bash
+# With uv (recommended)
+uv pip install upsonic python-dotenv
+
+# With pip
+pip install upsonic python-dotenv
+```
+
+## Example: Monthly Revenue Report
+
+The agent fetches payment data from Stripe and writes a revenue report with breakdowns by product, customer segment, and payment method.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+stripe_handler = MCPHandler(
+    command="npx -y @stripe/mcp --tools=all",
+    env={
+        "STRIPE_SECRET_KEY": os.getenv("STRIPE_SECRET_KEY")
+    },
+    timeout_seconds=60
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./revenue-reports",
+    tools=[stripe_handler]
+)
+
+task = Task(
+    description="""
+    Generate a monthly revenue report from Stripe data.
+
+    1. Fetch all successful payments from the last 30 days
+    2. Fetch all active subscriptions
+
+    Write the following files:
+    - 'payments.csv' with columns: date, customer_email, amount, currency,
+      product, payment_method
+    - 'revenue_report.md' with sections:
+      * Total Revenue (sum of all payments)
+      * Revenue by Product (table)
+      * Payment Method Distribution (card vs bank transfer vs other)
+      * Monthly Recurring Revenue (MRR) from active subscriptions
+      * Top 10 Customers by Spend
+    """
+)
+
+agent.print_do(task)
+```
+
+## Example: Subscription Churn Analysis
+
+The agent analyzes subscription data to identify churn patterns and exports the findings.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+stripe_handler = MCPHandler(
+    command="npx -y @stripe/mcp --tools=all",
+    env={
+        "STRIPE_SECRET_KEY": os.getenv("STRIPE_SECRET_KEY")
+    },
+    timeout_seconds=60
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./analytics",
+    tools=[stripe_handler]
+)
+
+task = Task(
+    description="""
+    Analyze subscription churn from Stripe data.
+
+    1. Fetch all subscriptions (active, canceled, and past_due)
+    2. For canceled subscriptions, note the cancellation date and plan
+
+    Write the following files:
+    - 'subscriptions.csv' with columns: customer_email, plan, status,
+      start_date, cancel_date, monthly_amount
+    - 'churn_analysis.md' with:
+      * Active vs Canceled vs Past Due counts
+      * Churn rate (canceled / total)
+      * Most churned plan (which plan loses the most subscribers)
+      * At-risk subscriptions (past_due) with customer details
+      * Recommendations for reducing churn
+    """
+)
+
+agent.print_do(task)
+```
+
+## Available Tools
+
+The Stripe MCP server exposes tools including:
+
+| Tool | Description |
+|------|-------------|
+| `list_customers` | List customers with optional filters |
+| `create_customer` | Create a new customer |
+| `list_payments` | List payment intents |
+| `create_payment_link` | Create a shareable payment link |
+| `list_subscriptions` | List subscriptions |
+| `list_products` | List available products |
+| `get_balance` | Get current account balance |
+
+<Warning>
+**Use test mode keys for development.** Never use live Stripe keys during development or testing. Test mode keys start with `sk_test_` and live keys start with `sk_live_`.
+</Warning>
+
+## Security Notes
+
+- Always use **test mode** API keys (`sk_test_...`) during development.
+- Use restricted API keys with only the permissions your agent needs.
+- Store your API key in `.env` — never hardcode it.
+- For production, restrict key permissions to read-only where possible.

--- a/concepts/tools/mcp-tools/examples/twitter-agent.mdx
+++ b/concepts/tools/mcp-tools/examples/twitter-agent.mdx
@@ -1,0 +1,171 @@
+---
+title: "Twitter (X) MCP Agent"
+description: "Build an autonomous agent that analyzes Twitter/X data and generates social media reports"
+sidebarTitle: "Twitter (X)"
+---
+
+## Overview
+
+Build an autonomous agent that connects to Twitter/X, collects social data — mentions, keyword trends, engagement metrics — and generates analytics reports in your workspace.
+
+<Info>
+This example uses [`@enescinar/twitter-mcp`](https://www.npmjs.com/package/@enescinar/twitter-mcp), a community-maintained MCP server — not an official Twitter/X product. Review the package source and permissions before providing your API credentials.
+</Info>
+
+## Prerequisites
+
+- A [Twitter Developer Account](https://developer.x.com/) with API access
+- API Key, API Secret, Access Token, and Access Token Secret from the [Developer Portal](https://developer.x.com/en/portal/dashboard)
+- Node.js installed (for `npx`)
+
+## Environment Variables
+
+```bash
+# .env
+TWITTER_API_KEY=your-api-key
+TWITTER_API_SECRET=your-api-secret
+TWITTER_ACCESS_TOKEN=your-access-token
+TWITTER_ACCESS_TOKEN_SECRET=your-access-token-secret
+ANTHROPIC_API_KEY=your-anthropic-key-here
+```
+
+<Tip>
+Get these credentials from the [Twitter Developer Portal](https://developer.x.com/en/portal/dashboard). Create a project and app, then generate your API keys and access tokens under the "Keys and tokens" tab.
+</Tip>
+
+## Installation
+
+```bash
+# With uv (recommended)
+uv pip install upsonic python-dotenv
+
+# With pip
+pip install upsonic python-dotenv
+```
+
+## Example: Brand Sentiment Report
+
+The agent searches for mentions of a brand or keyword, performs sentiment analysis, and generates a report with CSV data.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+twitter_handler = MCPHandler(
+    command="npx -y @enescinar/twitter-mcp",
+    env={
+        "API_KEY": os.getenv("TWITTER_API_KEY"),
+        "API_SECRET_KEY": os.getenv("TWITTER_API_SECRET"),
+        "ACCESS_TOKEN": os.getenv("TWITTER_ACCESS_TOKEN"),
+        "ACCESS_TOKEN_SECRET": os.getenv("TWITTER_ACCESS_TOKEN_SECRET")
+    },
+    timeout_seconds=60
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./social-reports",
+    tools=[twitter_handler]
+)
+
+task = Task(
+    description="""
+    Search Twitter for recent tweets mentioning "upsonic" or "AI agents"
+    from the last 7 days. Collect at least 50 tweets.
+
+    For each tweet, classify the sentiment as: positive, neutral, or negative.
+
+    Write the following files:
+    - 'tweets.csv' with columns: date, author, text, likes, retweets,
+      replies, sentiment
+    - 'sentiment_report.md' with:
+      * Total tweets analyzed
+      * Sentiment distribution (table with counts and percentages)
+      * Top 5 most engaging tweets (highest likes + retweets)
+      * Common themes in positive mentions
+      * Common complaints in negative mentions
+      * Key influencers (authors with highest follower counts)
+      * Recommendations for engagement strategy
+    """
+)
+
+agent.print_do(task)
+```
+
+## Example: Competitor Monitoring Dashboard
+
+The agent tracks multiple competitors and creates a comparative analysis report.
+
+```python
+import os
+from dotenv import load_dotenv
+from upsonic import AutonomousAgent, Task
+from upsonic.tools.mcp import MCPHandler
+
+load_dotenv()
+
+twitter_handler = MCPHandler(
+    command="npx -y @enescinar/twitter-mcp",
+    env={
+        "API_KEY": os.getenv("TWITTER_API_KEY"),
+        "API_SECRET_KEY": os.getenv("TWITTER_API_SECRET"),
+        "ACCESS_TOKEN": os.getenv("TWITTER_ACCESS_TOKEN"),
+        "ACCESS_TOKEN_SECRET": os.getenv("TWITTER_ACCESS_TOKEN_SECRET")
+    },
+    timeout_seconds=60
+)
+
+agent = AutonomousAgent(
+    model="anthropic/claude-sonnet-4-6",
+    workspace="./social-reports",
+    tools=[twitter_handler]
+)
+
+task = Task(
+    description="""
+    Monitor Twitter activity for three AI agent frameworks:
+    "langchain", "crewai", and "upsonic".
+
+    For each framework, search recent tweets and collect:
+    - Tweet volume (number of mentions)
+    - Average engagement (likes + retweets per tweet)
+    - Overall sentiment
+
+    Write the following files:
+    - 'competitor_data.csv' with columns: framework, date, tweet_count,
+      avg_likes, avg_retweets, positive_pct, negative_pct
+    - 'competitor_report.md' with:
+      * Comparison table (volume, engagement, sentiment per framework)
+      * Share of voice analysis (% of total mentions)
+      * Notable tweets for each framework
+      * Trending topics per framework
+      * Competitive positioning insights
+    """
+)
+
+agent.print_do(task)
+```
+
+## Available Tools
+
+Twitter MCP servers typically expose tools including:
+
+| Tool | Description |
+|------|-------------|
+| `search_tweets` | Search for tweets by keyword or query |
+| `post_tweet` | Post a new tweet |
+| `get_user_tweets` | Get recent tweets from a user |
+| `get_mentions` | Get mentions of the authenticated user |
+| `reply_to_tweet` | Reply to a specific tweet |
+| `get_tweet` | Get details of a specific tweet |
+
+## Security Notes
+
+- Use a dedicated Twitter app with read-only permissions for analytics agents.
+- Store all API keys and tokens in `.env` — never hardcode them.
+- Twitter API has rate limits — set appropriate `tool_call_limit` to avoid hitting them.
+- Only grant write permissions if the agent needs to post or reply.

--- a/docs.json
+++ b/docs.json
@@ -260,9 +260,21 @@
                   {
                     "group": "MCP Tools",
                     "pages": [
+                      "concepts/tools/mcp-tools/overview",
                       "concepts/tools/mcp-tools/mcp-handler",
                       "concepts/tools/mcp-tools/multi-mcp-handler",
-                      "concepts/tools/mcp-tools/authentication"
+                      "concepts/tools/mcp-tools/authentication",
+                      {
+                        "group": "Examples",
+                        "pages": [
+                          "concepts/tools/mcp-tools/examples/github-agent",
+                          "concepts/tools/mcp-tools/examples/notion-agent",
+                          "concepts/tools/mcp-tools/examples/stripe-agent",
+                          "concepts/tools/mcp-tools/examples/google-calendar-agent",
+                          "concepts/tools/mcp-tools/examples/gmail-agent",
+                          "concepts/tools/mcp-tools/examples/twitter-agent"
+                        ]
+                      }
                     ]
                   },
                   {


### PR DESCRIPTION
Add step-by-step MCP agent examples for 5 integrations:         
                                                                    
- GitHub (`@modelcontextprotocol/server-github`)                  
- Google Calendar (`@cocal/google-calendar-mcp`)                  
- Notion (`@notionhq/notion-mcp-server`)                          
- Stripe (`@stripe/mcp`)                                          
- Twitter/X (`@enescinar/twitter-mcp`)                            
                                                                    
 Each example includes prerequisites, setup, env config, and working code samples. 