### PR TITLE
docs(usage-registry): TECH-1625 — unify metrics docs around .usage surface

### DIFF
--- a/concepts/agents/metrics.mdx
+++ b/concepts/agents/metrics.mdx
@@ -1,20 +1,20 @@
 ---
-title: Agent Metrics
-sidebarTitle: Agent Metrics
-description: Track your Agent's token usage, timing, and costs across all runs
+title: "Agent Metrics"
+sidebarTitle: "Metrics"
+description: "Track tokens, cost, requests, tool calls, and timing across every model call this agent participates in."
 ---
 
 ## Overview
 
-Your **Agent** keeps a single **`usage`** object (`AgentUsage`) that accumulates metrics over every run. Use it to monitor total tokens, requests, tool calls, cost, and detailed timing breakdowns for that agent.
+Every agent exposes a single read-only **`agent.usage`** property. It returns an `AggregatedUsage` view derived from the [centralized usage registry](/concepts/usage-registry) on each access, scoped to this agent's `agent_usage_id`.
 
-For a quick, JSON-friendly snapshot of session spend, you can also use **`agent.cost`** — a dictionary that aggregates the same token and cost figures across every task the agent has executed. See [Quick Session Summary via `agent.cost`](#quick-session-summary-via-agent-cost) below.
+Sub-pipeline model calls — memory summarization, reliability validator/editor, culture, policy, and sub-agents invoked as tools — automatically inherit the agent's scope and roll into `agent.usage` without any manual propagation.
 
 When printing is enabled (`print_do` / `print_do_async`), an **Agent Metrics** panel is displayed after each task so you can see the updated totals.
 
 ## Accessing Agent Metrics
 
-On any `Agent` instance, use **`agent.usage`**. It returns an `AgentUsage` object (or `None` before the first run).
+Read **`agent.usage`** on any `Agent` instance. It always returns an `AggregatedUsage` — zero-valued before the first run, populated thereafter.
 
 ### Token Metrics
 
@@ -23,9 +23,9 @@ On any `Agent` instance, use **`agent.usage`**. It returns an `AgentUsage` objec
 | `input_tokens` | `int` | Total prompt/input tokens across all runs |
 | `output_tokens` | `int` | Total completion/output tokens across all runs |
 | `total_tokens` | `int` | Sum of `input_tokens + output_tokens` |
-| `cache_write_tokens` | `int` | Total tokens written to the cache |
-| `cache_read_tokens` | `int` | Total tokens read from the cache |
-| `reasoning_tokens` | `int` | Total tokens used for reasoning (e.g. chain-of-thought) |
+| `cache_read_tokens` | `int` | Tokens read from prompt cache |
+| `cache_write_tokens` | `int` | Tokens written to prompt cache |
+| `reasoning_tokens` | `int` | Reasoning (chain-of-thought) tokens |
 
 ### Request & Tool Metrics
 
@@ -38,65 +38,24 @@ On any `Agent` instance, use **`agent.usage`**. It returns an `AgentUsage` objec
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `duration` | `float \| None` | Total execution time across all runs (seconds) |
-| `model_execution_time` | `float \| None` | Total time spent inside LLM API calls (seconds) |
-| `tool_execution_time` | `float \| None` | Total time spent executing tools across all runs (seconds) |
-| `upsonic_execution_time` | `float \| None` | Framework overhead = `duration - model_execution_time - tool_execution_time` (seconds) |
+| `duration` | `float` | Sum of per-call durations across contributing entries (seconds) |
+| `model_execution_time` | `float` | Total time spent inside LLM API calls (seconds) |
+| `tool_execution_time` | `float` | Total time spent executing tools (seconds) |
+| `upsonic_execution_time` | `float` | Framework overhead = `duration − model − tool` (seconds) |
+| `time_to_first_token` | `float \| None` | Earliest TTFT across contributing entries |
 
 ### Cost Metrics
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `cost` | `float \| None` | Estimated total cost across all runs (provider-specific) |
+| `cost` | `float \| None` | Sum of `cost_usd` across contributing entries. `None` if no entry was priced; `0.0` means priced and free. |
 
+### Aggregation Metadata
 
-## Quick Session Summary via `agent.cost`
-
-`agent.cost` is a convenience property that returns a single dictionary aggregating tokens and estimated cost across **every** task the agent has executed (`do`, `do_async`, `run`, `run_async`). It's especially useful for autonomous agents and prebuilt agents that dispatch several tasks per run — bootstrap, workspace setup, the user's prompt, sub-agents — so the dictionary reports the full session spend, not just the last task.
-
-- Returns **`None`** before any task has been executed.
-- Returns a `dict[str, Any]` once the agent has run at least one task.
-- `estimated_cost` is in USD and is `None` when the model's pricing cannot be resolved.
-
-| Key | Type | Description |
-|-----|------|-------------|
-| `input_tokens` | `int` | Total prompt/input tokens across all runs |
-| `output_tokens` | `int` | Total completion/output tokens across all runs |
-| `total_tokens` | `int` | `input_tokens + output_tokens` |
-| `estimated_cost` | `float \| None` | Estimated total cost in USD (or `None` if pricing not resolvable) |
-| `requests` | `int` | Total number of LLM API requests |
-| `tool_calls` | `int` | Total number of tool calls executed |
-| `cache_read_tokens` | `int` | Total tokens read from cache |
-| `cache_write_tokens` | `int` | Total tokens written to cache |
-| `reasoning_tokens` | `int` | Total reasoning/chain-of-thought tokens |
-
-```python
-from upsonic import Agent, Task
-
-agent = Agent("anthropic/claude-sonnet-4-5")
-agent.do(Task("What is 2 + 2? Reply with one number."))
-agent.do(Task("What is 3 + 3? Reply with one number."))
-
-summary = agent.cost
-# {
-#   'input_tokens': 184,
-#   'output_tokens': 10,
-#   'total_tokens': 194,
-#   'estimated_cost': 0.000702,
-#   'requests': 2,
-#   'tool_calls': 0,
-#   'cache_read_tokens': 0,
-#   'cache_write_tokens': 0,
-#   'reasoning_tokens': 0,
-# }
-
-print(f"Spent ${summary['estimated_cost']:.4f} over {summary['requests']} requests")
-```
-
-<Note>
-`agent.cost` and `agent.usage` are **complementary, not duplicative**. `agent.usage` is the full `AgentUsage` object with timing breakdowns (`duration`, `model_execution_time`, etc.); `agent.cost` is a flat dictionary focused on tokens and money — convenient for logging, dashboards, or returning over an API.
-</Note>
-
+| Property | Type | Description |
+|----------|------|-------------|
+| `entry_count` | `int` | Number of underlying `UsageEntry` rows contributing to this view |
+| `models` | `list[str]` | Distinct model identifiers that contributed (first-seen order) |
 
 ## Example
 
@@ -113,12 +72,12 @@ print(f"Requests:        {u.requests}")
 print(f"Input tokens:    {u.input_tokens}")
 print(f"Output tokens:   {u.output_tokens}")
 print(f"Tool calls:      {u.tool_calls}")
-print(f"Cost:            ${u.cost:.4f}")
-print(f"Duration:        {u.duration:.2f}s")
+if u.cost is not None:
+    print(f"Cost:            ${u.cost:.4f}")
 print(f"Model time:      {u.model_execution_time:.2f}s")
-if u.tool_execution_time is not None:
-    print(f"Tool time:       {u.tool_execution_time:.2f}s")
+print(f"Tool time:       {u.tool_execution_time:.2f}s")
 print(f"Framework time:  {u.upsonic_execution_time:.2f}s")
+print(f"Models used:     {u.models}")
 ```
 
 ## Printed Panel
@@ -141,8 +100,29 @@ When you use `print_do` or `print_do_async`, the **Agent Metrics** panel display
 ╰───────────────────────────────────────────────────────╯
 ```
 
-## Accumulation Behavior
+## Scope & Propagation
 
-- **Across tasks**: Every call to `do` / `print_do` / `do_async` / `print_do_async` adds to the same `agent.usage`. The `AgentUsage` object accumulates each task's `TaskUsage` via its `incr()` method.
-- **Sub-agent propagation**: When an agent uses another agent as a tool, the sub-agent's usage (tokens, requests, tool calls, cost, timing) is propagated into the parent agent's `usage`.
-- **Independent agents**: Each `Agent` instance has its own independent `AgentUsage`. Two different agents never share usage.
+- **Across tasks** — Every call to `do` / `print_do` / `do_async` / `print_do_async` records entries against the agent's scope. Reading `agent.usage` re-aggregates them, so the figures always reflect the latest state.
+- **Sub-pipeline rollup** — Memory summarization, reliability validator/editor, culture, policy, and sub-agent calls inherit the parent's scope via context variables and roll into `agent.usage` automatically.
+- **Retry idempotency** — The registry is keyed by `entry_id`. Retried requests replace their prior entry instead of double-counting.
+- **Independent agents** — Each `Agent` instance has its own `agent_usage_id`. Two different agents never share usage.
+- **JSON snapshot** — Call `agent.usage.to_dict()` for a flat dict suitable for logs and dashboards.
+
+## Legacy Migration
+
+<Note>
+Legacy surfaces have been removed in favour of `agent.usage`:
+
+| Legacy | Replacement |
+|--------|-------------|
+| `agent.cost` (dict) | `agent.usage.to_dict()` |
+| `AgentUsage.incr()` / accumulator fields | (registry-derived; no mutation needed) |
+| `agent._finalize_agent_usage`, retry baseline machinery | (registry is idempotent) |
+</Note>
+
+## Related Documentation
+
+- [Usage Registry](/concepts/usage-registry) — Architecture, scope tags, persistence
+- [Task Metrics](/concepts/tasks/metrics) — Per-task scoped view
+- [Chat Metrics](/concepts/chat/metrics) — Per-session scoped view
+- [Team Metrics](/concepts/team/metrics) — Per-team scoped view

--- a/concepts/chat.mdx
+++ b/concepts/chat.mdx
@@ -78,7 +78,8 @@ async def main():
 
     # Access chat history
     print(chat.all_messages)
-    print(f"Total cost: ${chat.total_cost}")
+    if chat.usage.cost is not None:
+        print(f"Total cost: ${chat.usage.cost:.4f}")
 
 
 if __name__ == "__main__":
@@ -235,21 +236,18 @@ async for chunk in chat.stream("Explain quantum computing"):
 
 ```python
 # Get session information
-print(f"Session state: {chat.state}")
-print(f"Total messages: {len(chat.all_messages)}")
-print(f"Input tokens: {chat.input_tokens}")
-print(f"Output tokens: {chat.output_tokens}")
-print(f"Total cost: ${chat.total_cost:.4f}")
+print(f"Session state:   {chat.state}")
+print(f"Total messages:  {len(chat.all_messages)}")
+print(f"Input tokens:    {chat.usage.input_tokens}")
+print(f"Output tokens:   {chat.usage.output_tokens}")
+if chat.usage.cost is not None:
+    print(f"Total cost:      ${chat.usage.cost:.4f}")
 
-# Get session metrics
-metrics = chat.get_session_metrics()
-print(f"Session duration: {metrics.duration:.1f}s")
-print(f"Average response time: {metrics.average_response_time:.2f}s")
+# Session timing (wall-clock)
+print(f"Session duration: {chat.duration:.1f}s")
 
-# Get cost history
-cost_history = chat.get_cost_history()
-for entry in cost_history:
-    print(f"Cost: ${entry['estimated_cost']:.4f} - {entry['model_name']}")
+# Models that contributed to this session
+print(f"Models used:     {chat.usage.models}")
 ```
 
 ## Session State Management
@@ -326,32 +324,34 @@ response = await chat.invoke("What programming language do I prefer?")
 ### Cost Monitoring
 
 ```python
-# Track costs across the session
-print(f"Total cost: ${chat.total_cost:.4f}")
-print(f"Input tokens: {chat.input_tokens}")
-print(f"Output tokens: {chat.output_tokens}")
+# Track costs across the session via the unified usage view
+u = chat.usage
+if u.cost is not None:
+    print(f"Total cost:     ${u.cost:.4f}")
+print(f"Input tokens:   {u.input_tokens}")
+print(f"Output tokens:  {u.output_tokens}")
+print(f"Requests:       {u.requests}")
+print(f"Tool calls:     {u.tool_calls}")
+print(f"Models used:    {u.models}")
 
-# Get detailed cost breakdown
-cost_history = chat.get_cost_history()
-for entry in cost_history:
-    print(f"Model: {entry['model_name']}")
-    print(f"Cost: ${entry['estimated_cost']:.4f}")
-    print(f"Tokens: {entry['input_tokens']} in, {entry['output_tokens']} out")
+# JSON-friendly snapshot (for logs/dashboards)
+import json
+print(json.dumps(u.to_dict(), indent=2))
 ```
 
 ### Session Analytics
 
 ```python
-# Get comprehensive session metrics
-metrics = chat.get_session_metrics()
-print(f"Session duration: {metrics.duration:.1f}s")
-print(f"Messages per minute: {metrics.messages_per_minute:.1f}")
-print(f"Average response time: {metrics.average_response_time:.2f}s")
-print(f"Total cost: ${metrics.total_cost:.4f}")
-
-# Get session summary
-summary = chat.get_session_summary()
-print(summary)
+# Session timing and usage aggregate
+print(f"Session duration: {chat.duration:.1f}s")
+print(f"Total messages:   {len(chat.all_messages)}")
+print(f"Requests:         {chat.usage.requests}")
+print(f"Tool calls:       {chat.usage.tool_calls}")
+print(f"Model time:       {chat.usage.model_execution_time:.2f}s")
+print(f"Tool time:        {chat.usage.tool_execution_time:.2f}s")
+print(f"Framework time:   {chat.usage.upsonic_execution_time:.2f}s")
+if chat.usage.cost is not None:
+    print(f"Total cost:       ${chat.usage.cost:.4f}")
 ```
 
 ## Error Handling and Retry Logic
@@ -583,12 +583,12 @@ async def main():
         # Session analytics
         print("\n=== SESSION ANALYTICS ===")
         print(f"Total messages: {len(chat.all_messages)}")
-        print(f"Total cost: ${chat.total_cost:.4f}")
-        print(f"Input tokens: {chat.input_tokens}")
-        print(f"Output tokens: {chat.output_tokens}")
-        
-        # Session summary
-        print(f"\nSession summary:\n{chat.get_session_summary()}")
+        u = chat.usage
+        if u.cost is not None:
+            print(f"Total cost:     ${u.cost:.4f}")
+        print(f"Input tokens:   {u.input_tokens}")
+        print(f"Output tokens:  {u.output_tokens}")
+        print(f"Duration:       {chat.duration:.1f}s")
         
     finally:
         # Clean up

--- a/concepts/chat/attributes.mdx
+++ b/concepts/chat/attributes.mdx
@@ -31,17 +31,10 @@ description: "Configuration options for the Chat class"
 |----------|------|-------------|
 | `state` | `SessionState` | Current session state (IDLE, AWAITING_RESPONSE, STREAMING, ERROR) |
 | `all_messages` | `List[ChatMessage]` | All messages in the session |
-| `input_tokens` | `int` | Total input tokens used |
-| `output_tokens` | `int` | Total output tokens used |
-| `total_tokens` | `int` | Total tokens (input + output) |
-| `total_cost` | `float` | Total cost in USD |
-| `total_requests` | `int` | Total API requests made |
-| `total_tool_calls` | `int` | Total tool calls made |
-| `run_duration` | `float` | Total run duration in seconds |
-| `time_to_first_token` | `float` | Time to first token in seconds |
+| `usage` | `AggregatedUsage` | Read-only view over every model call recorded for this session — tokens, cost, requests, tool calls, timing. See [Metrics](/concepts/chat/metrics). |
 | `start_time` | `float` | Session start time (Unix timestamp) |
 | `end_time` | `float` | Session end time (None if active) |
-| `duration` | `float` | Session duration in seconds |
+| `duration` | `float` | Wall-clock session duration in seconds |
 | `last_activity` | `float` | Time since last activity in seconds |
 | `is_closed` | `bool` | Whether the session is closed |
 
@@ -69,8 +62,9 @@ async def main():
     print(response)
 
     print(f"State: {chat.state.value}")
-    print(f"Cost: ${chat.total_cost:.4f}")
-    print(f"Tokens: {chat.total_tokens}")
+    if chat.usage.cost is not None:
+        print(f"Cost: ${chat.usage.cost:.4f}")
+    print(f"Tokens: {chat.usage.total_tokens}")
 
 
 if __name__ == "__main__":

--- a/concepts/chat/examples/basic.mdx
+++ b/concepts/chat/examples/basic.mdx
@@ -26,7 +26,8 @@ async def main():
     print(f"Assistant: {response2}")
 
     print(f"\nMessages: {len(chat.all_messages)}")
-    print(f"Cost: ${chat.total_cost:.4f}")
+    if chat.usage.cost is not None:
+        print(f"Cost: ${chat.usage.cost:.4f}")
 
 
 if __name__ == "__main__":

--- a/concepts/chat/metrics.mdx
+++ b/concepts/chat/metrics.mdx
@@ -1,11 +1,72 @@
 ---
-title: "Metrics"
-description: "Cost tracking and session analytics"
+title: "Chat Metrics"
+sidebarTitle: "Metrics"
+description: "Track tokens, cost, requests, tool calls, and timing across an entire chat session."
 ---
 
-## Token and Cost Tracking
+## Overview
 
-Access usage metrics via properties:
+Every chat session exposes a single read-only **`chat.usage`** property. It returns an `AggregatedUsage` view derived from the [centralized usage registry](/concepts/usage-registry) on each access, scoped to this chat's `chat_usage_id`.
+
+The session's own agent calls, sub-agents, memory summarization, reliability passes, culture, and policy checks all inherit the chat scope and roll into `chat.usage` automatically.
+
+For wall-clock session length, use `chat.duration` (or `chat.end_time - chat.start_time` for an explicit window).
+
+## Accessing Chat Metrics
+
+Read **`chat.usage`** on any `Chat` instance. It always returns an `AggregatedUsage` — zero-valued before the first message, populated thereafter.
+
+### Token Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `input_tokens` | `int` | Prompt tokens across all model calls in the session |
+| `output_tokens` | `int` | Completion tokens across all model calls |
+| `total_tokens` | `int` | Sum of `input_tokens + output_tokens` |
+| `cache_read_tokens` | `int` | Tokens read from prompt cache |
+| `cache_write_tokens` | `int` | Tokens written to prompt cache |
+| `reasoning_tokens` | `int` | Reasoning (chain-of-thought) tokens |
+
+### Request & Tool Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requests` | `int` | Number of LLM API requests across the session |
+| `tool_calls` | `int` | Number of tool calls across the session |
+
+### Timing Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `duration` | `float` | Sum of per-call durations recorded on entries (seconds) |
+| `model_execution_time` | `float` | Total time spent inside LLM API calls (seconds) |
+| `tool_execution_time` | `float` | Total time spent executing tools (seconds) |
+| `upsonic_execution_time` | `float` | Framework overhead = `duration − model − tool` (seconds) |
+| `time_to_first_token` | `float \| None` | Earliest TTFT across contributing entries |
+
+### Cost Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `cost` | `float \| None` | Sum of `cost_usd` across contributing entries. `None` if no entry was priced; `0.0` means priced and free. |
+
+### Aggregation Metadata
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `entry_count` | `int` | Number of underlying `UsageEntry` rows contributing to this view |
+| `models` | `list[str]` | Distinct model identifiers that contributed (first-seen order) |
+
+### Session Wall-Clock & Messages
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `chat.duration` | `float` | Wall-clock session length in seconds |
+| `chat.start_time` | `float` | Unix timestamp when the session opened |
+| `chat.end_time` | `float \| None` | Unix timestamp when the session closed (`None` if active) |
+| `len(chat.all_messages)` | `int` | Total messages in the session |
+
+## Example
 
 ```python
 import asyncio
@@ -19,89 +80,70 @@ async def main():
     await chat.invoke("Hello")
     await chat.invoke("How are you?")
 
-    print(f"Total cost: ${chat.total_cost:.4f}")
-    print(f"Input tokens: {chat.input_tokens}")
-    print(f"Output tokens: {chat.output_tokens}")
-    print(f"Total tokens: {chat.total_tokens}")
-    print(f"Total requests: {chat.total_requests}")
+    u = chat.usage
+    print(f"Requests:        {u.requests}")
+    print(f"Input tokens:    {u.input_tokens}")
+    print(f"Output tokens:   {u.output_tokens}")
+    print(f"Tool calls:      {u.tool_calls}")
+    if u.cost is not None:
+        print(f"Cost:            ${u.cost:.4f}")
+    print(f"Model time:      {u.model_execution_time:.2f}s")
+    print(f"Tool time:       {u.tool_execution_time:.2f}s")
+    print(f"Framework time:  {u.upsonic_execution_time:.2f}s")
+    print(f"Models used:     {u.models}")
+
+    # Wall-clock session length
+    print(f"Wall-clock:      {chat.duration:.1f}s")
+    print(f"Messages:        {len(chat.all_messages)}")
 
 
 if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-## Session Metrics
-
-Get comprehensive metrics via `get_session_metrics()`:
+## JSON-Friendly Output
 
 ```python
-import asyncio
-from upsonic import Agent, Chat
+import json
 
-
-async def main():
-    agent = Agent("anthropic/claude-sonnet-4-5")
-    chat = Chat(session_id="session1", user_id="user1", agent=agent)
-
-    await chat.invoke("Hello")
-
-    metrics = chat.get_session_metrics()
-    print(f"Duration: {metrics.duration:.1f}s")
-    print(f"Messages: {metrics.message_count}")
-    print(f"Total cost: ${metrics.total_cost:.4f}")
-    print(f"Avg response time: {metrics.average_response_time:.2f}s")
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
+snapshot = {
+    **chat.usage.to_dict(),
+    "duration_wallclock": chat.duration,
+    "messages": len(chat.all_messages),
+}
+print(json.dumps(snapshot, indent=2))
 ```
 
-## Session Summary
+## Scope & Propagation
 
-Get a human-readable summary:
+- **Across invocations** — Every `chat.invoke` / `chat.stream` adds entries under the chat's scope. Reading `chat.usage` re-aggregates them, so the figures always reflect the latest state.
+- **Sub-pipeline rollup** — Memory summarization, reliability validator/editor, culture, policy, and sub-agent calls inherit the chat scope via context variables and roll into `chat.usage` automatically.
+- **Retry idempotency** — The registry is keyed by `entry_id`. Retried requests replace their prior entry instead of double-counting.
+- **Persistence** — When you configure storage on `Chat`, recorded entries persist alongside the conversation. Re-opening the same `session_id` re-hydrates the registry, so `chat.usage` continues from where it left off across processes and restarts.
 
-```python
-import asyncio
-from upsonic import Agent, Chat
+## Legacy Migration
 
+<Note>
+Legacy chat-level properties and helpers have been removed in favour of `chat.usage`:
 
-async def main():
-    agent = Agent("anthropic/claude-sonnet-4-5")
-    chat = Chat(session_id="session1", user_id="user1", agent=agent)
+| Legacy | Replacement |
+|--------|-------------|
+| `chat.input_tokens` | `chat.usage.input_tokens` |
+| `chat.output_tokens` | `chat.usage.output_tokens` |
+| `chat.total_tokens` | `chat.usage.total_tokens` |
+| `chat.total_cost` | `chat.usage.cost` |
+| `chat.total_requests` | `chat.usage.requests` |
+| `chat.total_tool_calls` | `chat.usage.tool_calls` |
+| `chat.run_duration`, `chat.time_to_first_token` | `chat.usage.duration`, `chat.usage.time_to_first_token` |
+| `chat.get_usage()` | `chat.usage` |
+| `chat.get_session_metrics()`, `chat.get_session_summary()`, `SessionMetrics` | `chat.usage` + `chat.duration` + `len(chat.all_messages)` |
+| `chat.get_cost_history()` | (registry query — filter `UsageEntry` rows by `chat_usage_id`) |
+</Note>
 
-    await chat.invoke("Hello")
-    await chat.invoke("How are you?")
+## Related Documentation
 
-    summary = chat.get_session_summary()
-    print(summary)
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
-```
-
-## Run Usage Object
-
-Access the full usage object:
-
-```python
-import asyncio
-from upsonic import Agent, Chat
-
-
-async def main():
-    agent = Agent("anthropic/claude-sonnet-4-5")
-    chat = Chat(session_id="session1", user_id="user1", agent=agent)
-
-    await chat.invoke("Hello")
-
-    usage = chat.get_usage()
-    if usage:
-        print(f"Input tokens: {usage.input_tokens}")
-        print(f"Output tokens: {usage.output_tokens}")
-        print(f"Cost: ${usage.cost:.4f}")
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
-```
+- [Usage Registry](/concepts/usage-registry) — Architecture, scope tags, persistence
+- [Agent Metrics](/concepts/agents/metrics) — Accumulated agent-level view
+- [Task Metrics](/concepts/tasks/metrics) — Per-task scoped view
+- [Team Metrics](/concepts/team/metrics) — Per-team scoped view
+- [Storage Backends](/concepts/chat/storage-backends) — Persisting usage across processes

--- a/concepts/chat/overview.mdx
+++ b/concepts/chat/overview.mdx
@@ -37,7 +37,8 @@ async def main():
     response = await chat.invoke("Hello, how are you?")
     print(response)
 
-    print(f"Total cost: ${chat.total_cost:.4f}")
+    if chat.usage.cost is not None:
+        print(f"Total cost: ${chat.usage.cost:.4f}")
     print(f"Messages: {len(chat.all_messages)}")
 
 

--- a/concepts/task.mdx
+++ b/concepts/task.mdx
@@ -425,24 +425,24 @@ print(f"Task response: {task.response}")
 
 ```python
 # Access task metadata
-print(f"Task ID: {task.task_id}")
-print(f"Price ID: {task.price_id}")
-print(f"Duration: {task.duration}")
-print(f"Start time: {task.start_time}")
-print(f"End time: {task.end_time}")
+print(f"Task ID:       {task.task_id}")
+print(f"Task Usage ID: {task.task_usage_id}")
+print(f"Start time:    {task.start_time}")
+print(f"End time:      {task.end_time}")
+if task.start_time and task.end_time:
+    print(f"Wall-clock:    {(task.end_time - task.start_time):.2f}s")
 ```
 
 ### Cost Information
 
 ```python
-# Access cost information
-total_cost = task.total_cost
-input_tokens = task.total_input_token
-output_tokens = task.total_output_token
-
-print(f"Total cost: ${total_cost}")
-print(f"Input tokens: {input_tokens}")
-print(f"Output tokens: {output_tokens}")
+# Access cost information via the unified usage view
+u = task.usage
+if u.cost is not None:
+    print(f"Total cost:   ${u.cost:.6f}")
+print(f"Input tokens:  {u.input_tokens}")
+print(f"Output tokens: {u.output_tokens}")
+print(f"Requests:      {u.requests}")
 ```
 
 ### Tool Call History
@@ -506,12 +506,15 @@ result = agent.do(task)
 
 # Access all available information
 print("=== TASK EXECUTION SUMMARY ===")
-print(f"Task ID: {task.get_task_id()}")
-print(f"Duration: {task.duration:.2f} seconds")
-print(f"Cost: ${task.total_cost}")
-print(f"Tokens: {task.total_input_token} in, {task.total_output_token} out")
-print(f"Tool calls made: {len(task.tool_calls)}")
-print(f"Cache hit: {task._cache_hit}")
+print(f"Task ID:        {task.get_task_id()}")
+if task.start_time and task.end_time:
+    print(f"Wall-clock:     {(task.end_time - task.start_time):.2f} seconds")
+u = task.usage
+if u.cost is not None:
+    print(f"Cost:           ${u.cost:.6f}")
+print(f"Tokens:         {u.input_tokens} in, {u.output_tokens} out")
+print(f"Tool calls:     {len(task.tool_calls)}")
+print(f"Cache hit:      {task.cache_hit}")
 
 print("\n=== TASK RESULT ===")
 print(f"Result: {result}")

--- a/concepts/tasks/attributes.mdx
+++ b/concepts/tasks/attributes.mdx
@@ -73,8 +73,8 @@ The Task class provides the following read-only properties:
 |----------|------|-------------|
 | `id` | str | Get the task ID. Auto-generates a UUID if not set |
 | `task_id` | str | Get the task ID. Auto-generates a UUID if not set |
-| `price_id` | str | Get the price ID for cost tracking. Auto-generates a UUID if not set |
-| `duration` | float \| None | Get task execution duration in seconds (end_time - start_time). Returns `None` if not started or not ended |
+| `task_usage_id` | str | Scope tag used to filter the centralized usage registry for this task. Auto-generated if not set |
+| `usage` | `AggregatedUsage` | Read-only view over the usage registry filtered by `task_usage_id` — tokens, cost, requests, tool calls, timing. See [Task Metrics](/concepts/tasks/metrics). |
 | `response` | str \| bytes \| None | Get the task response. Returns `None` if not yet set |
 | `context_formatted` | str \| None | Get the formatted context string (read-only). Set by context management process |
 | `run_id` | str \| None | Get the run ID associated with this task. Allows task continuation with a new agent instance |
@@ -82,9 +82,6 @@ The Task class provides the following read-only properties:
 | `is_completed` | bool | Check if the task's run is already completed. A completed task cannot be re-run or continued |
 | `cache_hit` | bool | Check if the last response was retrieved from cache |
 | `tool_calls` | List[Dict[str, Any]] | Get all tool calls made during this task's execution. Each dict contains 'tool_name', 'params', and 'tool_result' |
-| `total_cost` | float \| None | Get the total estimated cost of this task in USD. Returns `None` if not available |
-| `total_input_token` | int \| None | Get the total number of input tokens used by this task. Returns `None` if not available |
-| `total_output_token` | int \| None | Get the total number of output tokens used by this task. Returns `None` if not available |
 | `attachments_base64` | List[str] \| None | Convert all attachment files to base64 encoded strings. Returns `None` if no attachments |
 
 ## Methods
@@ -123,7 +120,6 @@ The Task class provides the following read-only properties:
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `get_task_id` | `get_task_id() -> str` | Get formatted task ID as "Task_{first_8_chars}" |
-| `get_total_cost` | `get_total_cost() -> Optional[Dict[str, Any]]` | Get total cost information including estimated_cost, input_tokens, and output_tokens |
 | `to_dict` | `to_dict(serialize_flag: bool = False) -> Dict[str, Any]` | Convert task to dictionary. If `serialize_flag=True`, uses cloudpickle for tools, guardrail, and response_format |
 | `from_dict` | `@classmethod from_dict(data: Dict[str, Any], deserialize_flag: bool = False) -> Task` | Reconstruct Task from dictionary. If `deserialize_flag=True`, uses cloudpickle to deserialize pickled fields |
 
@@ -140,8 +136,8 @@ The following attributes are internal and typically not set by users:
 - `_last_cache_entry`: Internal storage for last cache entry
 - `_run_id`: Internal run ID for task continuation
 - `_task_todos`: Internal todo list for task planning
-- `price_id_`: Internal price ID (use `price_id` property)
 - `task_id_`: Internal task ID (use `task_id` property)
+- `task_usage_id_`: Internal usage-scope tag (use `task_usage_id` property)
 - `agent`: Internal reference to agent instance
 
 ## Configuration Examples
@@ -283,13 +279,16 @@ task = Task(
 agent.print_do(task)
 
 # Access task properties
-print(f"Task ID: {task.id}")
-print(f"Duration: {task.duration:.2f} seconds")
-print(f"Status: {task.status}")
-print(f"Total Cost: ${task.total_cost:.4f}")
-print(f"Input Tokens: {task.total_input_token}")
-print(f"Output Tokens: {task.total_output_token}")
-print(f"Tool Calls: {len(task.tool_calls)}")
+print(f"Task ID:      {task.id}")
+if task.start_time and task.end_time:
+    print(f"Wall-clock:   {(task.end_time - task.start_time):.2f} seconds")
+print(f"Status:       {task.status}")
+u = task.usage
+if u.cost is not None:
+    print(f"Total Cost:   ${u.cost:.4f}")
+print(f"Input Tokens: {u.input_tokens}")
+print(f"Output Tokens:{u.output_tokens}")
+print(f"Tool Calls:   {len(task.tool_calls)}")
 
 # Check task state
 if task.is_completed:

--- a/concepts/tasks/metrics.mdx
+++ b/concepts/tasks/metrics.mdx
@@ -1,68 +1,72 @@
 ---
-title: Task Metrics
-sidebarTitle: Task Metrics
-description: Track token usage, timing, and costs for individual task executions
+title: "Task Metrics"
+sidebarTitle: "Metrics"
+description: "Track tokens, cost, requests, tool calls, and timing for a single task execution."
 ---
 
 ## Overview
 
-Every task execution tracks detailed metrics including token counts, timing breakdowns, estimated cost, and tool calls. All timing and token data lives in `task.usage` (`TaskUsage`) — the single source of truth for task-level metrics.
+Every task exposes a single read-only **`task.usage`** property. It returns an `AggregatedUsage` view derived from the [centralized usage registry](/concepts/usage-registry) on each access, scoped to this task's `task_usage_id`.
 
-When printing is enabled (`print_do` / `print_do_async`), a **Task Metrics** panel is displayed after each task execution.
+For wall-clock task length, compute `task.end_time - task.start_time`. The figure on `task.usage.duration` is the **sum of per-call model durations**, not wall-clock.
+
+When printing is enabled (`print_do` / `print_do_async`), a **Task Metrics** panel is displayed after each execution.
 
 ## Accessing Task Metrics
 
-After executing a task, metrics are available directly on the `Task` instance.
+Read **`task.usage`** on any `Task` instance after execution. It always returns an `AggregatedUsage` — zero-valued before any model call, populated thereafter.
 
-### Token & Cost Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `total_input_token` | `int \| None` | Number of input/prompt tokens used |
-| `total_output_token` | `int \| None` | Number of output/completion tokens generated |
-| `total_cost` | `float \| None` | Estimated cost in USD |
-| `price_id` | `str` | Unique identifier for tracking this task's pricing |
-
-### Timing Properties
+### Token Metrics
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `duration` | `float \| None` | Total wall-clock execution time (seconds) |
-| `model_execution_time` | `float \| None` | Time spent inside LLM API calls (seconds) |
-| `tool_execution_time` | `float \| None` | Time spent executing tools (seconds) |
-| `upsonic_execution_time` | `float \| None` | Framework overhead = `duration - model_execution_time - tool_execution_time` (seconds) |
+| `input_tokens` | `int` | Prompt tokens for this task |
+| `output_tokens` | `int` | Completion tokens for this task |
+| `total_tokens` | `int` | Sum of `input_tokens + output_tokens` |
+| `cache_read_tokens` | `int` | Tokens read from prompt cache |
+| `cache_write_tokens` | `int` | Tokens written to prompt cache |
+| `reasoning_tokens` | `int` | Reasoning (chain-of-thought) tokens |
+
+### Request & Tool Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requests` | `int` | Number of LLM API requests for this task |
+| `tool_calls` | `int` | Number of tool calls executed for this task |
+
+### Timing Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `duration` | `float` | Sum of per-call durations recorded on entries (seconds) |
+| `model_execution_time` | `float` | Total time spent inside LLM API calls (seconds) |
+| `tool_execution_time` | `float` | Total time spent executing tools (seconds) |
+| `upsonic_execution_time` | `float` | Framework overhead = `duration − model − tool` (seconds) |
+| `time_to_first_token` | `float \| None` | Earliest TTFT across contributing entries |
+
+### Cost Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `cost` | `float \| None` | Sum of `cost_usd` across contributing entries. `None` if no entry was priced; `0.0` means priced and free. |
+
+### Aggregation Metadata
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `entry_count` | `int` | Number of underlying `UsageEntry` rows contributing to this view |
+| `models` | `list[str]` | Distinct model identifiers that contributed (first-seen order) |
+
+### Task Identity & Wall-Clock Timing
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `task_id` | `str` | Stable identifier for the task |
+| `task_usage_id` | `str` | Scope tag used to filter the usage registry for this task |
 | `start_time` | `float \| None` | Unix timestamp when the task started |
 | `end_time` | `float \| None` | Unix timestamp when the task finished |
 
-### Response & Tool Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `response` | `str \| BaseModel \| None` | The task's output after execution |
-| `tool_calls` | `list[dict]` | List of tool calls made during execution |
-
-### The `usage` Property (TaskUsage)
-
-`task.usage` returns the underlying `TaskUsage` object — the single source of truth for all task-level metrics. The timing properties above (`duration`, `model_execution_time`, `upsonic_execution_time`) delegate directly to this object.
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `requests` | `int` | Number of LLM API requests made for this task |
-| `tool_calls` | `int` | Number of tool calls executed during this task |
-| `input_tokens` | `int` | Input tokens (accumulated from model responses) |
-| `output_tokens` | `int` | Output tokens (accumulated from model responses) |
-| `total_tokens` | `int` | Sum of `input_tokens + output_tokens` |
-| `cache_write_tokens` | `int` | Tokens written to cache |
-| `cache_read_tokens` | `int` | Tokens read from cache |
-| `reasoning_tokens` | `int` | Tokens used for reasoning |
-| `duration` | `float \| None` | Total task execution time (seconds) |
-| `model_execution_time` | `float \| None` | Time in LLM API calls (seconds) |
-| `tool_execution_time` | `float \| None` | Time spent executing tools (seconds) |
-| `upsonic_execution_time` | `float \| None` | Framework overhead time (seconds) |
-| `cost` | `float \| None` | Estimated cost of this task |
-
-
-## Basic Usage
+## Example
 
 ```python
 from upsonic import Agent, Task
@@ -72,109 +76,68 @@ task = Task("Summarize the key benefits of AI agents in production systems")
 
 agent.print_do(task)
 
-print(f"Cost:             ${task.total_cost:.6f}")
-print(f"Input tokens:     {task.total_input_token}")
-print(f"Output tokens:    {task.total_output_token}")
-print(f"Duration:         {task.duration:.2f}s")
-print(f"Model time:       {task.model_execution_time:.2f}s")
-print(f"Tool time:        {(task.tool_execution_time or 0):.2f}s")
-print(f"Framework time:   {task.upsonic_execution_time:.2f}s")
+u = task.usage
+print(f"Requests:        {u.requests}")
+print(f"Input tokens:    {u.input_tokens}")
+print(f"Output tokens:   {u.output_tokens}")
+print(f"Tool calls:      {u.tool_calls}")
+if u.cost is not None:
+    print(f"Cost:            ${u.cost:.6f}")
+print(f"Model time:      {u.model_execution_time:.2f}s")
+print(f"Tool time:       {u.tool_execution_time:.2f}s")
+print(f"Framework time:  {u.upsonic_execution_time:.2f}s")
+print(f"Models used:     {u.models}")
+
+# Wall-clock task length
+if task.start_time and task.end_time:
+    print(f"Wall-clock:      {(task.end_time - task.start_time):.2f}s")
 ```
 
 ## Printed Panel
 
-When you use `print_do` or `print_do_async`, the **Task Metrics** panel is displayed:
+When you use `print_do` or `print_do_async`, the **Task Metrics** panel displays after the task:
 
 ```
 ╭──────────────────── Task Metrics ─────────────────────╮
-│  Price ID:              a1b2c3d4-e5f6-...             │
+│  Task Usage ID:         a1b2c3d4-e5f6-...             │
 │                                                       │
 │  Input Tokens:          762                           │
 │  Output Tokens:         408                           │
 │  Total Estimated Cost:  $0.0004                       │
-│  Time Taken:            10.55 seconds                 │
 │  Model Execution Time:  7.99 seconds                  │
 │  Tool Execution Time:   1.00 seconds                  │
 │  Framework Overhead:    1.56 seconds                  │
 ╰───────────────────────────────────────────────────────╯
 ```
 
-## Accessing Usage Directly
+## Scope & Propagation
 
-For programmatic access to the full usage data, use `task.usage`:
+- **Per-task isolation** — Each task has its own `task_usage_id`. Two tasks executed by the same agent never mix their `task.usage` figures.
+- **Agent rollup** — The same entries that contribute to `task.usage` also contribute to `agent.usage` (and `chat.usage` / `team.usage` if applicable) because every entry carries multiple scope tags.
+- **Sub-pipeline rollup** — Reliability validator/editor, culture, policy, and sub-agent calls dispatched during this task inherit `task_usage_id` and roll into `task.usage` automatically.
+- **Retry idempotency** — The registry is keyed by `entry_id`. Retried requests replace their prior entry instead of double-counting.
+- **JSON snapshot** — Call `task.usage.to_dict()` for a flat dict suitable for logs and dashboards.
 
-```python
-from upsonic import Agent, Task
+## Legacy Migration
 
-agent = Agent("anthropic/claude-sonnet-4-5")
-task = Task("What is 2 + 2?")
-agent.do(task)
+<Note>
+Legacy task-level properties have been removed in favour of `task.usage`:
 
-u = task.usage
-print(f"Input tokens:     {u.input_tokens}")
-print(f"Output tokens:    {u.output_tokens}")
-print(f"Duration:         {u.duration:.2f}s")
-print(f"Model time:       {u.model_execution_time:.2f}s")
-print(f"Tool time:        {u.tool_execution_time or 0:.2f}s")
-print(f"Framework time:   {u.upsonic_execution_time:.2f}s")
-```
-
-## Monitoring Multiple Tasks
-
-```python
-from upsonic import Agent, Task
-
-agent = Agent("anthropic/claude-sonnet-4-5")
-
-tasks = [
-    Task("Analyze sentiment of customer feedback"),
-    Task("Extract key entities from the document"),
-    Task("Generate a summary report"),
-]
-
-for task in tasks:
-    agent.print_do(task)
-
-    print(f"Task: {task.description[:40]}...")
-    print(f"  Cost:      ${task.total_cost:.6f}")
-    print(f"  Tokens:    {task.total_input_token + task.total_output_token}")
-    print(f"  Duration:  {task.duration:.2f}s")
-    print(f"  Model:     {task.model_execution_time:.2f}s")
-    print(f"  Tool:      {(task.tool_execution_time or 0):.2f}s")
-    print(f"  Overhead:  {task.upsonic_execution_time:.2f}s\n")
-```
-
-## Independence Across Tasks
-
-Each task has its own independent `TaskUsage` instance. Running multiple tasks on the same agent does not mix their metrics:
-
-```python
-from upsonic import Agent, Task
-
-agent = Agent("anthropic/claude-sonnet-4-5")
-
-task_a = Task("Say hello.")
-task_b = Task("Say goodbye.")
-
-agent.do(task_a)
-agent.do(task_b)
-
-# Each task has its own usage
-assert task_a.usage is not task_b.usage
-print(f"Task A duration: {task_a.duration:.2f}s")
-print(f"Task B duration: {task_b.duration:.2f}s")
-```
-
-## Cost Optimization Tips
-
-1. **Choose the right model** — Use smaller models (`gpt-4o-mini`) for simple tasks
-2. **Optimize prompts** — Shorter, clearer prompts reduce input tokens
-3. **Use caching** — Enable [task caching](/concepts/tasks/task-caching) for repeated queries
-4. **Monitor timing** — Use `model_execution_time` vs `upsonic_execution_time` to identify bottlenecks
+| Legacy | Replacement |
+|--------|-------------|
+| `task.total_cost` | `task.usage.cost` |
+| `task.total_input_token` | `task.usage.input_tokens` |
+| `task.total_output_token` | `task.usage.output_tokens` |
+| `task.price_id`, `Task.price_id_` | `task.task_usage_id` |
+| `task.get_total_cost()` | `task.usage.to_dict()` |
+| `task.duration` | `task.end_time - task.start_time` (wall-clock) or `task.usage.duration` (sum of per-call) |
+| `task.model_execution_time`, `task.tool_execution_time`, `task.upsonic_execution_time` | `task.usage.X` |
+</Note>
 
 ## Related Documentation
 
-- [Agent Metrics](/metrics) — Accumulated agent-level usage across all runs
+- [Usage Registry](/concepts/usage-registry) — Architecture, scope tags, persistence
+- [Agent Metrics](/concepts/agents/metrics) — Accumulated agent-level view
+- [Chat Metrics](/concepts/chat/metrics) — Per-session scoped view
+- [Team Metrics](/concepts/team/metrics) — Per-team scoped view
 - [Task Caching](/concepts/tasks/task-caching) — Reduce costs with caching
-- [Task Attributes](/concepts/tasks/attributes) — All available task attributes
-- [Task Results](/concepts/tasks/results) — Accessing task execution results

--- a/concepts/tasks/results.mdx
+++ b/concepts/tasks/results.mdx
@@ -32,11 +32,12 @@ task = Task(description="Explain quantum computing in simple terms")
 agent.print_do(task)
 
 # Access task metadata
-print(f"Task ID: {task.task_id}")
-print(f"Price ID: {task.price_id}")
-print(f"Duration: {task.duration}")
-print(f"Start time: {task.start_time}")
-print(f"End time: {task.end_time}")
+print(f"Task ID:        {task.task_id}")
+print(f"Task Usage ID:  {task.task_usage_id}")
+print(f"Start time:     {task.start_time}")
+print(f"End time:       {task.end_time}")
+if task.start_time and task.end_time:
+    print(f"Wall-clock:     {(task.end_time - task.start_time):.2f}s")
 ```
 
 ## Cost Information
@@ -49,14 +50,13 @@ agent = Agent(model="anthropic/claude-sonnet-4-5")
 task = Task(description="Write a short poem about technology")
 agent.print_do(task)
 
-# Access cost information
-total_cost = task.total_cost
-input_tokens = task.total_input_token
-output_tokens = task.total_output_token
-
-print(f"Total cost: ${total_cost}")
-print(f"Input tokens: {input_tokens}")
-print(f"Output tokens: {output_tokens}")
+# Access cost information via the unified usage view
+u = task.usage
+if u.cost is not None:
+    print(f"Total cost:   ${u.cost:.6f}")
+print(f"Input tokens:  {u.input_tokens}")
+print(f"Output tokens: {u.output_tokens}")
+print(f"Requests:      {u.requests}")
 ```
 
 ## Tool Call History
@@ -130,12 +130,15 @@ result = agent.print_do(task)
 
 # Access all available information
 print("=== TASK EXECUTION SUMMARY ===")
-print(f"Task ID: {task.get_task_id()}")
-print(f"Duration: {task.duration:.2f} seconds")
-print(f"Cost: ${task.total_cost}")
-print(f"Tokens: {task.total_input_token} in, {task.total_output_token} out")
-print(f"Tool calls made: {len(task.tool_calls)}")
-print(f"Cache hit: {task._cache_hit}")
+print(f"Task ID:        {task.get_task_id()}")
+if task.start_time and task.end_time:
+    print(f"Wall-clock:     {(task.end_time - task.start_time):.2f} seconds")
+u = task.usage
+if u.cost is not None:
+    print(f"Cost:           ${u.cost:.6f}")
+print(f"Tokens:         {u.input_tokens} in, {u.output_tokens} out")
+print(f"Tool calls:     {len(task.tool_calls)}")
+print(f"Cache hit:      {task.cache_hit}")
 
 print("\n=== TASK RESULT ===")
 print(f"Result: {result}")
@@ -149,18 +152,17 @@ for key, value in cache_stats.items():
 
 ## Available Properties and Methods
 
-| Property/Method        | Type       | Description                        |
-| ---------------------- | ---------- | ---------------------------------- |
-| **response**           | Any        | The task's response output         |
-| **task_id**            | str        | Unique task identifier             |
-| **price_id**           | str        | Price tracking identifier          |
-| **duration**           | float      | Task execution duration in seconds |
-| **total_cost**         | float      | Estimated cost in USD              |
-| **total_input_token**  | int        | Number of input tokens used        |
-| **total_output_token** | int        | Number of output tokens generated  |
-| **tool_calls**         | List[Dict] | History of tool calls made         |
-| **get_cache_stats()**  | Dict       | Cache statistics and configuration |
-| **get_task_id()**      | str        | Formatted task ID for display      |
+| Property/Method        | Type              | Description                                                       |
+| ---------------------- | ----------------- | ----------------------------------------------------------------- |
+| **response**           | Any               | The task's response output                                        |
+| **task_id**            | str               | Unique task identifier                                            |
+| **task_usage_id**      | str               | Scope tag for filtering the usage registry to this task           |
+| **usage**              | `AggregatedUsage` | Read-only view of tokens / cost / requests / timing for this task |
+| **start_time**         | float \| None     | Unix timestamp when the task started                              |
+| **end_time**           | float \| None     | Unix timestamp when the task finished                             |
+| **tool_calls**         | List[Dict]        | History of tool calls made                                        |
+| **get_cache_stats()**  | Dict              | Cache statistics and configuration                                |
+| **get_task_id()**      | str               | Formatted task ID for display                                     |
 
 ## Best Practices
 

--- a/concepts/team/metrics.mdx
+++ b/concepts/team/metrics.mdx
@@ -1,0 +1,132 @@
+---
+title: "Team Metrics"
+sidebarTitle: "Metrics"
+description: "Track tokens, cost, requests, tool calls, and timing across every member of a team."
+---
+
+## Overview
+
+Every team exposes a single read-only **`team.usage`** property. It returns an `AggregatedUsage` view derived from the [centralized usage registry](/concepts/usage-registry) on each access, scoped to this team's `team_usage_id`.
+
+Each member's model calls — including sub-pipeline calls like memory summarization, reliability passes, culture, policy, and sub-agents — inherit the team scope and roll into `team.usage` automatically. Nested sub-teams contribute to their parent team's view as well.
+
+## Accessing Team Metrics
+
+Read **`team.usage`** on any `Team` instance. It always returns an `AggregatedUsage` — zero-valued before the first run, populated thereafter.
+
+### Token Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `input_tokens` | `int` | Prompt tokens across every team member's model calls |
+| `output_tokens` | `int` | Completion tokens across every team member's model calls |
+| `total_tokens` | `int` | Sum of `input_tokens + output_tokens` |
+| `cache_read_tokens` | `int` | Tokens read from prompt cache |
+| `cache_write_tokens` | `int` | Tokens written to prompt cache |
+| `reasoning_tokens` | `int` | Reasoning (chain-of-thought) tokens |
+
+### Request & Tool Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requests` | `int` | Total number of LLM API requests across the team |
+| `tool_calls` | `int` | Total number of tool calls across the team |
+
+### Timing Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `duration` | `float` | Sum of per-call durations recorded on entries (seconds) |
+| `model_execution_time` | `float` | Total time spent inside LLM API calls (seconds) |
+| `tool_execution_time` | `float` | Total time spent executing tools (seconds) |
+| `upsonic_execution_time` | `float` | Framework overhead = `duration − model − tool` (seconds) |
+| `time_to_first_token` | `float \| None` | Earliest TTFT across contributing entries |
+
+### Cost Metrics
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `cost` | `float \| None` | Sum of `cost_usd` across contributing entries. `None` if no entry was priced; `0.0` means priced and free. |
+
+### Aggregation Metadata
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `entry_count` | `int` | Number of underlying `UsageEntry` rows contributing to this view |
+| `models` | `list[str]` | Distinct model identifiers that contributed (first-seen order) |
+
+### Team Identity
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `team_id` | `str` | Stable identifier for the team |
+| `team_usage_id` | `str` | Scope tag used to filter the usage registry for this team |
+
+## Example
+
+```python
+from upsonic import Agent, Team
+
+team = Team(
+    entities=[
+        Agent("openai/gpt-4o-mini", name="Researcher"),
+        Agent("anthropic/claude-sonnet-4-5", name="Reviewer"),
+    ],
+)
+
+team.do("Plan and review a small feature.")
+
+u = team.usage
+print(f"Requests:        {u.requests}")
+print(f"Input tokens:    {u.input_tokens}")
+print(f"Output tokens:   {u.output_tokens}")
+print(f"Tool calls:      {u.tool_calls}")
+if u.cost is not None:
+    print(f"Cost:            ${u.cost:.4f}")
+print(f"Model time:      {u.model_execution_time:.2f}s")
+print(f"Tool time:       {u.tool_execution_time:.2f}s")
+print(f"Framework time:  {u.upsonic_execution_time:.2f}s")
+print(f"Models used:     {u.models}")
+```
+
+## JSON-Friendly Output
+
+```python
+import json
+
+snapshot = team.usage.to_dict()
+print(json.dumps(snapshot, indent=2))
+```
+
+## Scope & Propagation
+
+- **Across members** — Every team member's model call records an entry tagged with the team's `team_usage_id`. Reading `team.usage` re-aggregates all of them.
+- **Per-member breakdown** — Each agent still has its own `agent_usage_id`. To see one member in isolation, read that agent's `agent.usage`. The same entries contribute to both views (one entry, multiple scope tags).
+- **Sub-teams** — When a `Team` is nested inside another `Team`, the nested team's entries carry both `team_usage_id` tags, rolling up into the parent automatically.
+- **Sub-pipeline rollup** — Memory summarization, reliability validator/editor, culture, policy, and sub-agent calls dispatched by team members inherit the team scope via context variables.
+- **Retry idempotency** — The registry is keyed by `entry_id`. Retried requests replace their prior entry instead of double-counting.
+- **JSON snapshot** — Call `team.usage.to_dict()` for a flat dict suitable for logs and dashboards.
+
+## Per-Member Breakdown
+
+```python
+print("=== Team total ===")
+print(team.usage.to_dict())
+
+print("\n=== Per-member ===")
+for entity in team.entities:
+    print(f"{entity.name}: {entity.usage.to_dict()}")
+```
+
+## Legacy Migration
+
+<Note>
+`team.usage` is the unified entry point for all team-level metrics. There is no legacy `team.total_cost` / `team.input_tokens` / `team.get_session_metrics()` surface — `team.usage` was introduced as part of the centralized usage registry rollout.
+</Note>
+
+## Related Documentation
+
+- [Usage Registry](/concepts/usage-registry) — Architecture, scope tags, persistence
+- [Agent Metrics](/concepts/agents/metrics) — Per-member scoped view
+- [Task Metrics](/concepts/tasks/metrics) — Per-task scoped view
+- [Chat Metrics](/concepts/chat/metrics) — Per-session scoped view

--- a/concepts/usage-registry.mdx
+++ b/concepts/usage-registry.mdx
@@ -1,0 +1,148 @@
+---
+title: Usage Registry
+sidebarTitle: Usage Registry
+description: One append-only registry of every model call — read uniformly through agent.usage, task.usage, chat.usage, team.usage, and output.usage.
+---
+
+## Overview
+
+Upsonic records every model call into a single **centralized usage registry**. Tokens, cost, requests, tool calls, and timing are written exactly once per call, keyed by a unique `entry_id`, and tagged with the scopes the call belongs to. Reading metrics anywhere in the framework is a derived view over those rows — no manual rollups, no double-counting on retry.
+
+You never interact with the registry directly. Instead, every surface that has metrics exposes a single read-only **`.usage`** property:
+
+```python
+agent.usage       # rolled up across every model call this agent participated in
+task.usage        # filtered to this task's scope
+chat.usage        # filtered to this chat session
+team.usage        # filtered across a team and its members
+output.usage      # the per-run snapshot returned alongside an agent run
+```
+
+All five return the same shape — an `AggregatedUsage` view — so once you learn the fields, you can read them from anywhere.
+
+## The `AggregatedUsage` shape
+
+`AggregatedUsage` is a read-only dataclass derived from the registry on each access.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `input_tokens` | `int` | Prompt/input tokens |
+| `output_tokens` | `int` | Completion/output tokens |
+| `total_tokens` | `int` | `input_tokens + output_tokens` |
+| `cache_read_tokens` | `int` | Tokens read from prompt cache |
+| `cache_write_tokens` | `int` | Tokens written to prompt cache |
+| `reasoning_tokens` | `int` | Chain-of-thought / reasoning tokens |
+| `requests` | `int` | Number of model requests |
+| `tool_calls` | `int` | Number of tool calls |
+| `cost` | `float \| None` | Sum of `cost_usd` across contributing entries; `None` if nothing priced |
+| `duration` | `float` | Sum of per-call durations recorded on entries |
+| `model_execution_time` | `float` | Time spent inside model calls |
+| `tool_execution_time` | `float` | Time spent inside tool calls |
+| `upsonic_execution_time` | `float` | Framework overhead = `duration − model − tool` |
+| `time_to_first_token` | `float \| None` | Earliest TTFT across contributing entries |
+| `entry_count` | `int` | Number of contributing `UsageEntry` rows |
+| `models` | `list[str]` | Distinct models that contributed, first-seen order |
+
+```python
+u = agent.usage
+print(u.input_tokens, u.output_tokens, u.cost, u.models)
+print(u.to_dict())  # JSON-friendly flat dict for logs/dashboards
+```
+
+`cost` is `None` (rather than `0.0`) when **no** contributing entry was priced. `0.0` means at least one entry was priced and the total came out free.
+
+## Scope tags
+
+Every recorded `UsageEntry` carries scope tags so the same row can be filtered into multiple views:
+
+| Tag | Set by | Visible as |
+|-----|--------|------------|
+| `chat_usage_id` | `Chat` session | `chat.usage` |
+| `agent_usage_id` | `Agent` instance | `agent.usage` |
+| `task_usage_id` | `Task` | `task.usage` |
+| `team_usage_id` | `Team` | `team.usage` |
+| `workflow_usage_id` | StateGraph / workflow | (registry queries) |
+| `system_usage_id` | System-level groupings | (registry queries) |
+| `run_id` | Per-run identifier | `output.usage` (one run) |
+| `user_id` | Per-user identifier | (registry queries) |
+
+Scope tags are propagated through Python `contextvars`. Sub-pipeline LLM calls — memory summarization, reliability validator/editor, culture checks, policy enforcement, sub-agents — **automatically inherit** the parent's tags, so their spend rolls up into `agent.usage`, `chat.usage`, etc., without any explicit propagation step.
+
+## Idempotency and retries
+
+The registry is keyed by `entry_id`. Re-recording an entry with the same id **replaces** the prior row rather than adding a second one. Retried requests therefore never double-count, and there is no separate baseline/snapshot machinery to keep in sync.
+
+## Persistence
+
+When you configure a storage backend on `Chat`, recorded entries are persisted alongside the conversation. Re-opening the same `session_id` re-hydrates the registry, so `chat.usage` continues from where it left off across processes and restarts.
+
+Supported backends: InMemory, JSON, SQLite, PostgreSQL, MongoDB, Redis.
+
+## Examples
+
+### Per-task vs. per-agent
+
+```python
+from upsonic import Agent, Task
+
+agent = Agent("anthropic/claude-sonnet-4-5")
+t1 = Task("Say hello.")
+t2 = Task("Say goodbye.")
+agent.do(t1)
+agent.do(t2)
+
+print(t1.usage.total_tokens, t2.usage.total_tokens)  # per-task
+print(agent.usage.total_tokens)                       # both tasks + any sub-pipeline calls
+```
+
+### Chat sessions
+
+```python
+import asyncio
+from upsonic import Agent, Chat
+
+async def main():
+    chat = Chat(session_id="s1", user_id="u1", agent=Agent("anthropic/claude-sonnet-4-5"))
+    await chat.invoke("Hello")
+    await chat.invoke("How are you?")
+
+    u = chat.usage
+    if u.cost is not None:
+        print(f"${u.cost:.4f} across {u.requests} requests using {u.models}")
+    print(f"Wall-clock session length: {chat.duration:.1f}s")
+
+asyncio.run(main())
+```
+
+### Teams
+
+```python
+from upsonic import Agent, Team
+
+team = Team(agents=[Agent("openai/gpt-4o-mini"), Agent("anthropic/claude-sonnet-4-5")])
+team.do("Plan and review a small feature.")
+
+print(team.usage.to_dict())  # spend across every member + sub-pipeline call
+```
+
+## Migration from the legacy surface
+
+The following legacy surfaces have been removed in favour of `.usage`. If you have older code, the replacements are:
+
+| Legacy | Replacement |
+|--------|-------------|
+| `task.price_id`, `task.get_total_cost()`, `task.total_input_token`, `task.total_output_token` | `task.task_usage_id`, `task.usage.X` |
+| `task.duration`, `task.model_execution_time`, `task.tool_execution_time`, `task.upsonic_execution_time` | `task.usage.X` (per-call sums); for wall-clock use `task.end_time - task.start_time` |
+| `agent.cost` (dict) | `agent.usage.to_dict()` |
+| `chat.input_tokens`, `chat.output_tokens`, `chat.total_tokens`, `chat.total_cost`, `chat.total_requests`, `chat.total_tool_calls`, `chat.run_duration`, `chat.time_to_first_token` | `chat.usage.X` |
+| `chat.get_usage()`, `chat.get_session_metrics()`, `chat.get_session_summary()` | `chat.usage`; for message count `len(chat.all_messages)`; for wall-clock `chat.duration` |
+| `SessionMetrics` dataclass | `chat.usage` + `chat.duration` + `len(chat.all_messages)` |
+| `UPSONIC_LEGACY_USAGE` env flag | (removed; the unified registry is always on) |
+
+## Related Documentation
+
+- [Agent Metrics](/concepts/agents/metrics)
+- [Task Metrics](/concepts/tasks/metrics)
+- [Chat Metrics](/concepts/chat/metrics)
+- [Team Metrics](/concepts/team/metrics)
+- [Tracing Overview](/concepts/tracing/overview)

--- a/docs.json
+++ b/docs.json
@@ -345,6 +345,14 @@
                 ]
               },
               {
+                "group": "Usage Registry",
+                "icon": "gauge",
+                "tag": "NEW",
+                "pages": [
+                  "concepts/usage-registry"
+                ]
+              },
+              {
                 "group": "Tracing",
                 "icon": "chart-line",
                 "pages": [
@@ -565,7 +573,8 @@
                           "concepts/team/modes/route"
                         ]
                       },
-                      "concepts/team/assigning-tasks-manually"
+                      "concepts/team/assigning-tasks-manually",
+                      "concepts/team/metrics"
                     ],
                     "collapsed": false
                   },

--- a/reference/task/task.mdx
+++ b/reference/task/task.mdx
@@ -86,7 +86,7 @@ The following parameters are internal and typically not set by users:
 | `_last_cache_entry`                | `Optional[Dict[str, Any]]`                          | `None`     | Internal storage for last cache entry                                                                                                                                                                                                                  |
 | `_run_id`                          | `Optional[str]`                                       | `None`     | Internal run ID for task continuation                                                                                                                                                                                                  |
 | `_task_todos`                      | `Optional[TodoList]`                                 | `None`     | Internal todo list for task planning                                                                                                                                                                                                                   |
-| `price_id_`                        | `Optional[str]`                                       | `None`     | Internal price ID (use `price_id` property)                                                                                                                                                                                                        |
+| `task_usage_id_`                   | `Optional[str]`                                       | `None`     | Internal usage-scope tag (use `task_usage_id` property)                                                                                                                                                                                            |
 | `task_id_`                         | `Optional[str]`                                       | `None`     | Internal task ID (use `task_id` property)                                                                                                                                                                                                                           |
 | `agent`                            | `Optional[Agent]`                                       | `None`     | Internal reference to agent instance                                                                                                                                                                                                   |
 | `_run_output`                      | `Optional[AgentRunOutput]`                           | `None`     | The AgentRunOutput for this task                                                                                                                                                                                                  |
@@ -155,21 +155,23 @@ Get the task ID. Auto-generates a UUID if not set.
 
 - `str`: The task ID
 
-##### `price_id`
+##### `task_usage_id`
 
-Get the price ID for cost tracking. Auto-generates a UUID if not set.
-
-**Returns:**
-
-- `str`: The price ID
-
-##### `duration`
-
-Get task execution duration in seconds (end_time - start_time). Returns `None` if not started or not ended.
+Scope tag used to filter the centralized usage registry for this task. Auto-generates a UUID if not set.
 
 **Returns:**
 
-- `Optional[float]`: Task duration in seconds
+- `str`: The task usage ID
+
+##### `usage`
+
+Read-only `AggregatedUsage` view over the usage registry, filtered by `task_usage_id`. Exposes `input_tokens`, `output_tokens`, `total_tokens`, `cost`, `requests`, `tool_calls`, `model_execution_time`, `tool_execution_time`, `upsonic_execution_time`, `duration` (sum of per-call durations), `time_to_first_token`, `cache_read_tokens`, `cache_write_tokens`, `reasoning_tokens`, `models`, and `entry_count`.
+
+**Returns:**
+
+- `AggregatedUsage`: Read-only metrics view (never `None`; zero-valued before any model call)
+
+For wall-clock task length, compute `task.end_time - task.start_time`.
 
 ##### `response`
 
@@ -226,30 +228,6 @@ Get all tool calls made during this task's execution. Each dict contains 'tool_n
 **Returns:**
 
 - `List[Dict[str, Any]]`: A list of dictionaries containing information about tool calls
-
-##### `total_cost`
-
-Get the total estimated cost of this task in USD. Returns `None` if not available.
-
-**Returns:**
-
-- `Optional[float]`: The estimated cost in USD, or None if not available
-
-##### `total_input_token`
-
-Get the total number of input tokens used by this task. Returns `None` if not available.
-
-**Returns:**
-
-- `Optional[int]`: The number of input tokens, or None if not available
-
-##### `total_output_token`
-
-Get the total number of output tokens used by this task. Returns `None` if not available.
-
-**Returns:**
-
-- `Optional[int]`: The number of output tokens, or None if not available
 
 ##### `attachments_base64`
 
@@ -355,14 +333,6 @@ Get formatted task ID as "Task_{first_8_chars}".
 **Returns:**
 
 - `str`: Formatted task ID
-
-##### `get_total_cost`
-
-Get total cost information including estimated_cost, input_tokens, and output_tokens.
-
-**Returns:**
-
-- `Optional[Dict[str, Any]]`: Dictionary with cost information, or None if not available
 
 ##### Cache Management
 


### PR DESCRIPTION
## Summary

Resyncs the docs site with the TECH-1625 centralized usage registry rollout in the Upsonic repo ([Upsonic/Upsonic#602](https://github.com/Upsonic/Upsonic/pull/602)).

- **New** `concepts/usage-registry.mdx` — single concept page covering the centralized registry, `AggregatedUsage` shape, scope tags (`chat_usage_id` / `agent_usage_id` / `task_usage_id` / `team_usage_id` / `workflow_usage_id` / `system_usage_id` / `run_id` / `user_id`), idempotency, and storage-backed persistence.
- **New** `concepts/team/metrics.mdx` — Team-scoped metrics page, wired into the Team > Usage nav group.
- **Standardized** Agent / Task / Chat / Team metrics pages to one template: `sidebarTitle: "Metrics"`, identical section order (Overview → Token / Request & Tool / Timing / Cost / Aggregation Metadata → Example → Printed Panel where applicable → Scope & Propagation → Legacy Migration → Related).
- **Nav** Added top-level "Usage Registry" group near Tracing in `docs.json`.
- **Legacy resync** Dropped references to removed surfaces and replaced them with the unified `.usage.X` surface across `concepts/chat.mdx`, `concepts/chat/{overview,attributes,examples/basic}.mdx`, `concepts/task.mdx`, `concepts/tasks/{attributes,results}.mdx`, and `reference/task/task.mdx`:
  - `Chat.total_cost` / `input_tokens` / `output_tokens` / `total_tokens` / `total_requests` / `total_tool_calls` / `run_duration` / `time_to_first_token` / `get_usage()` / `get_session_metrics()` / `get_session_summary()` / `SessionMetrics` → `chat.usage.X` + `chat.duration` + `len(chat.all_messages)`
  - `Task.price_id` / `total_cost` / `total_input_token` / `total_output_token` / `get_total_cost()` / `duration` / `model_execution_time` / `tool_execution_time` / `upsonic_execution_time` → `task.task_usage_id`, `task.usage.X`, wall-clock via `task.end_time - task.start_time`
  - `agent.cost` (dict) → `agent.usage.to_dict()`

## Test plan

- [ ] `mintlify dev` — verify all four metrics pages render and use the standardized template
- [ ] `mintlify broken-links` — confirm no broken cross-links between the new Usage Registry page and the four metrics pages
- [ ] Sidebar — confirm "Usage Registry" group appears above Tracing and Team Metrics appears under Team > Usage
- [ ] Spot-check that no remaining references to removed legacy surfaces (`total_cost`, `price_id`, `get_session_metrics`, etc.) exist in updated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)